### PR TITLE
Accounting

### DIFF
--- a/docs/num-formatting/api.md
+++ b/docs/num-formatting/api.md
@@ -33,6 +33,7 @@ Specifies the format style.
 The supported values are:
 * `"decimal"`
 * `"currency"`
+* `"accounting"`
 * `"percent"`
 * `"scientific"`
 

--- a/docs/num-formatting/index.md
+++ b/docs/num-formatting/index.md
@@ -43,6 +43,16 @@ Standard number formatting can be specified by passing an options object or a st
 
         formatNumber(1234.5678, "c5", "bg"); // 1 234,56780 лв
 
+* **The `"a"` specifier**&mdash;Same as `"c"` but uses the currency accounting format.
+
+  > The locale numbers `currencies` data and the supplemental `currencyData` must be loaded for the currency formatting to work.
+
+        import { formatNumber } from '@telerik/kendo-intl';
+
+        formatNumber(-1234.5678, "a"); // ($1,234.57)
+
+        formatNumber(1234.5678, "a3", "de-CH"); // 1’234.568 CHF
+
 * **The `"p"` specifier**&mdash;Formats the number as a percentage based on the locale. The passed number is multiplied by 100. To specify precision, add a number after `"p"`. By default, the number is formatted and rounded to zero decimal digits.
 
         import { formatNumber } from '@telerik/kendo-intl';
@@ -69,7 +79,7 @@ Standard number formatting can be specified by passing an options object or a st
         }); // 1,234.5678
 
         formatNumber(1234.5678, {
-            style: "currency",            
+            style: "currency",
             currency: "EUR",
             currencyDisplay: "displayName"
         }, "bg"); // 1 234,57 евро
@@ -90,7 +100,7 @@ The supported format specifiers are:
 
         import { formatNumber } from '@telerik/kendo-intl';
 
-        formatNumber(1234.5678, "00000"); // 01235    
+        formatNumber(1234.5678, "00000"); // 01235
 
 * **The `"#"` specifier**&mdash;A digit placeholder. It replaces the Pound sign with the corresponding digit if one is present. Otherwise, no digit appears in the result string.
 

--- a/locale-tests/generated-locales.js
+++ b/locale-tests/generated-locales.js
@@ -81,6 +81,18 @@ describe('generated-locales', () => {
                         }).not.toThrow();
                     });
 
+                    it('format accounting', () => {
+                        expect(() => {
+                            formatNumber(number, 'a', locale);
+                        }).not.toThrow();
+                    });
+
+                    it('parse accounting', () => {
+                        expect(() => {
+                            parseNumber(numberString, locale, 'a');
+                        }).not.toThrow();
+                    });
+
                 });
             }
 
@@ -145,6 +157,18 @@ describe('generated-locales', () => {
                     it('parse currency', () => {
                         expect(() => {
                             parseNumber(numberString, locale, 'c');
+                        }).not.toThrow();
+                    });
+
+                    it('format accounting', () => {
+                        expect(() => {
+                            formatNumber(number, 'a', locale);
+                        }).not.toThrow();
+                    });
+
+                    it('parse accounting', () => {
+                        expect(() => {
+                            parseNumber(numberString, locale, 'a');
                         }).not.toThrow();
                     });
                 }

--- a/locale-tests/locales/af-NA/all.js
+++ b/locale-tests/locales/af-NA/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ADP",

--- a/locale-tests/locales/af-NA/numbers.js
+++ b/locale-tests/locales/af-NA/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/af/all.js
+++ b/locale-tests/locales/af/all.js
@@ -51,6 +51,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ADP",

--- a/locale-tests/locales/af/numbers.js
+++ b/locale-tests/locales/af/numbers.js
@@ -53,6 +53,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/am/all.js
+++ b/locale-tests/locales/am/all.js
@@ -51,6 +51,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ADP",

--- a/locale-tests/locales/am/numbers.js
+++ b/locale-tests/locales/am/numbers.js
@@ -53,6 +53,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ar-AE/all.js
+++ b/locale-tests/locales/ar-AE/all.js
@@ -56,6 +56,15 @@ const data = {
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "بيستا أندوري",

--- a/locale-tests/locales/ar-AE/numbers.js
+++ b/locale-tests/locales/ar-AE/numbers.js
@@ -58,6 +58,15 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ar-BH/all.js
+++ b/locale-tests/locales/ar-BH/all.js
@@ -56,6 +56,15 @@ const data = {
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "بيستا أندوري",

--- a/locale-tests/locales/ar-BH/numbers.js
+++ b/locale-tests/locales/ar-BH/numbers.js
@@ -58,6 +58,15 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ar-DJ/all.js
+++ b/locale-tests/locales/ar-DJ/all.js
@@ -56,6 +56,15 @@ const data = {
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "بيستا أندوري",

--- a/locale-tests/locales/ar-DJ/numbers.js
+++ b/locale-tests/locales/ar-DJ/numbers.js
@@ -58,6 +58,15 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ar-DZ/all.js
+++ b/locale-tests/locales/ar-DZ/all.js
@@ -56,6 +56,15 @@ const data = {
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "بيستا أندوري",

--- a/locale-tests/locales/ar-DZ/numbers.js
+++ b/locale-tests/locales/ar-DZ/numbers.js
@@ -58,6 +58,15 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ar-EG/all.js
+++ b/locale-tests/locales/ar-EG/all.js
@@ -56,6 +56,15 @@ const data = {
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "بيستا أندوري",

--- a/locale-tests/locales/ar-EG/numbers.js
+++ b/locale-tests/locales/ar-EG/numbers.js
@@ -58,6 +58,15 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ar-EH/all.js
+++ b/locale-tests/locales/ar-EH/all.js
@@ -56,6 +56,15 @@ const data = {
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "بيستا أندوري",

--- a/locale-tests/locales/ar-EH/numbers.js
+++ b/locale-tests/locales/ar-EH/numbers.js
@@ -58,6 +58,15 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ar-ER/all.js
+++ b/locale-tests/locales/ar-ER/all.js
@@ -56,6 +56,15 @@ const data = {
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "بيستا أندوري",

--- a/locale-tests/locales/ar-ER/numbers.js
+++ b/locale-tests/locales/ar-ER/numbers.js
@@ -58,6 +58,15 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ar-IL/all.js
+++ b/locale-tests/locales/ar-IL/all.js
@@ -56,6 +56,15 @@ const data = {
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "بيستا أندوري",

--- a/locale-tests/locales/ar-IL/numbers.js
+++ b/locale-tests/locales/ar-IL/numbers.js
@@ -58,6 +58,15 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ar-IQ/all.js
+++ b/locale-tests/locales/ar-IQ/all.js
@@ -56,6 +56,15 @@ const data = {
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "بيستا أندوري",

--- a/locale-tests/locales/ar-IQ/numbers.js
+++ b/locale-tests/locales/ar-IQ/numbers.js
@@ -58,6 +58,15 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ar-JO/all.js
+++ b/locale-tests/locales/ar-JO/all.js
@@ -56,6 +56,15 @@ const data = {
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "بيستا أندوري",

--- a/locale-tests/locales/ar-JO/numbers.js
+++ b/locale-tests/locales/ar-JO/numbers.js
@@ -58,6 +58,15 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ar-KM/all.js
+++ b/locale-tests/locales/ar-KM/all.js
@@ -56,6 +56,15 @@ const data = {
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "بيستا أندوري",

--- a/locale-tests/locales/ar-KM/numbers.js
+++ b/locale-tests/locales/ar-KM/numbers.js
@@ -58,6 +58,15 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ar-KW/all.js
+++ b/locale-tests/locales/ar-KW/all.js
@@ -56,6 +56,15 @@ const data = {
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "بيستا أندوري",

--- a/locale-tests/locales/ar-KW/numbers.js
+++ b/locale-tests/locales/ar-KW/numbers.js
@@ -58,6 +58,15 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ar-LB/all.js
+++ b/locale-tests/locales/ar-LB/all.js
@@ -56,6 +56,15 @@ const data = {
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "بيستا أندوري",

--- a/locale-tests/locales/ar-LB/numbers.js
+++ b/locale-tests/locales/ar-LB/numbers.js
@@ -58,6 +58,15 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ar-LY/all.js
+++ b/locale-tests/locales/ar-LY/all.js
@@ -56,6 +56,15 @@ const data = {
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "بيستا أندوري",

--- a/locale-tests/locales/ar-LY/numbers.js
+++ b/locale-tests/locales/ar-LY/numbers.js
@@ -58,6 +58,15 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ar-MA/all.js
+++ b/locale-tests/locales/ar-MA/all.js
@@ -56,6 +56,15 @@ const data = {
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "بيستا أندوري",

--- a/locale-tests/locales/ar-MA/numbers.js
+++ b/locale-tests/locales/ar-MA/numbers.js
@@ -58,6 +58,15 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ar-MR/all.js
+++ b/locale-tests/locales/ar-MR/all.js
@@ -56,6 +56,15 @@ const data = {
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "بيستا أندوري",

--- a/locale-tests/locales/ar-MR/numbers.js
+++ b/locale-tests/locales/ar-MR/numbers.js
@@ -58,6 +58,15 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ar-OM/all.js
+++ b/locale-tests/locales/ar-OM/all.js
@@ -56,6 +56,15 @@ const data = {
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "بيستا أندوري",

--- a/locale-tests/locales/ar-OM/numbers.js
+++ b/locale-tests/locales/ar-OM/numbers.js
@@ -58,6 +58,15 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ar-PS/all.js
+++ b/locale-tests/locales/ar-PS/all.js
@@ -56,6 +56,15 @@ const data = {
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "بيستا أندوري",

--- a/locale-tests/locales/ar-PS/numbers.js
+++ b/locale-tests/locales/ar-PS/numbers.js
@@ -58,6 +58,15 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ar-QA/all.js
+++ b/locale-tests/locales/ar-QA/all.js
@@ -56,6 +56,15 @@ const data = {
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "بيستا أندوري",

--- a/locale-tests/locales/ar-QA/numbers.js
+++ b/locale-tests/locales/ar-QA/numbers.js
@@ -58,6 +58,15 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ar-SA/all.js
+++ b/locale-tests/locales/ar-SA/all.js
@@ -56,6 +56,15 @@ const data = {
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "بيستا أندوري",

--- a/locale-tests/locales/ar-SA/numbers.js
+++ b/locale-tests/locales/ar-SA/numbers.js
@@ -58,6 +58,15 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ar-SD/all.js
+++ b/locale-tests/locales/ar-SD/all.js
@@ -56,6 +56,15 @@ const data = {
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "بيستا أندوري",

--- a/locale-tests/locales/ar-SD/numbers.js
+++ b/locale-tests/locales/ar-SD/numbers.js
@@ -58,6 +58,15 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ar-SO/all.js
+++ b/locale-tests/locales/ar-SO/all.js
@@ -56,6 +56,15 @@ const data = {
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "بيستا أندوري",

--- a/locale-tests/locales/ar-SO/numbers.js
+++ b/locale-tests/locales/ar-SO/numbers.js
@@ -58,6 +58,15 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ar-SS/all.js
+++ b/locale-tests/locales/ar-SS/all.js
@@ -56,6 +56,15 @@ const data = {
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "بيستا أندوري",

--- a/locale-tests/locales/ar-SS/numbers.js
+++ b/locale-tests/locales/ar-SS/numbers.js
@@ -58,6 +58,15 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ar-SY/all.js
+++ b/locale-tests/locales/ar-SY/all.js
@@ -56,6 +56,15 @@ const data = {
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "بيستا أندوري",

--- a/locale-tests/locales/ar-SY/numbers.js
+++ b/locale-tests/locales/ar-SY/numbers.js
@@ -58,6 +58,15 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ar-TD/all.js
+++ b/locale-tests/locales/ar-TD/all.js
@@ -56,6 +56,15 @@ const data = {
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "بيستا أندوري",

--- a/locale-tests/locales/ar-TD/numbers.js
+++ b/locale-tests/locales/ar-TD/numbers.js
@@ -58,6 +58,15 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ar-TN/all.js
+++ b/locale-tests/locales/ar-TN/all.js
@@ -56,6 +56,15 @@ const data = {
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "بيستا أندوري",

--- a/locale-tests/locales/ar-TN/numbers.js
+++ b/locale-tests/locales/ar-TN/numbers.js
@@ -58,6 +58,15 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ar-YE/all.js
+++ b/locale-tests/locales/ar-YE/all.js
@@ -56,6 +56,15 @@ const data = {
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "بيستا أندوري",

--- a/locale-tests/locales/ar-YE/numbers.js
+++ b/locale-tests/locales/ar-YE/numbers.js
@@ -58,6 +58,15 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ar/all.js
+++ b/locale-tests/locales/ar/all.js
@@ -55,6 +55,15 @@ const data = {
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "بيستا أندوري",

--- a/locale-tests/locales/ar/numbers.js
+++ b/locale-tests/locales/ar/numbers.js
@@ -57,6 +57,15 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/az-Latn/all.js
+++ b/locale-tests/locales/az-Latn/all.js
@@ -52,6 +52,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$ n"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andora Pesetası",

--- a/locale-tests/locales/az-Latn/numbers.js
+++ b/locale-tests/locales/az-Latn/numbers.js
@@ -54,6 +54,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$ n"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/az/all.js
+++ b/locale-tests/locales/az/all.js
@@ -51,6 +51,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$ n"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andora Pesetası",

--- a/locale-tests/locales/az/numbers.js
+++ b/locale-tests/locales/az/numbers.js
@@ -53,6 +53,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$ n"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/be/all.js
+++ b/locale-tests/locales/be/all.js
@@ -53,6 +53,14 @@ const data = {
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ADP",

--- a/locale-tests/locales/be/numbers.js
+++ b/locale-tests/locales/be/numbers.js
@@ -55,6 +55,14 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/bg/all.js
+++ b/locale-tests/locales/bg/all.js
@@ -51,6 +51,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Андорска песета",

--- a/locale-tests/locales/bg/numbers.js
+++ b/locale-tests/locales/bg/numbers.js
@@ -53,6 +53,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/bn-IN/all.js
+++ b/locale-tests/locales/bn-IN/all.js
@@ -55,6 +55,16 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n$",
+                "(n$)"
+            ],
+            groupSize: [
+                3,
+                2
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "এ্যান্ডোরান পেসেতা",

--- a/locale-tests/locales/bn-IN/numbers.js
+++ b/locale-tests/locales/bn-IN/numbers.js
@@ -57,6 +57,16 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n$",
+                "(n$)"
+            ],
+            groupSize: [
+                3,
+                2
+            ]
         }
     }
 };

--- a/locale-tests/locales/bn/all.js
+++ b/locale-tests/locales/bn/all.js
@@ -54,6 +54,16 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n$",
+                "(n$)"
+            ],
+            groupSize: [
+                3,
+                2
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "এ্যান্ডোরান পেসেতা",

--- a/locale-tests/locales/bn/numbers.js
+++ b/locale-tests/locales/bn/numbers.js
@@ -56,6 +56,16 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n$",
+                "(n$)"
+            ],
+            groupSize: [
+                3,
+                2
+            ]
         }
     }
 };

--- a/locale-tests/locales/bs-Latn/all.js
+++ b/locale-tests/locales/bs-Latn/all.js
@@ -53,6 +53,14 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorska pezeta",

--- a/locale-tests/locales/bs-Latn/numbers.js
+++ b/locale-tests/locales/bs-Latn/numbers.js
@@ -55,6 +55,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-few": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/bs/all.js
+++ b/locale-tests/locales/bs/all.js
@@ -52,6 +52,14 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorska pezeta",

--- a/locale-tests/locales/bs/numbers.js
+++ b/locale-tests/locales/bs/numbers.js
@@ -54,6 +54,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-few": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ca-AD/all.js
+++ b/locale-tests/locales/ca-AD/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "pesseta andorrana",

--- a/locale-tests/locales/ca-AD/numbers.js
+++ b/locale-tests/locales/ca-AD/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ca-ES-VALENCIA/all.js
+++ b/locale-tests/locales/ca-ES-VALENCIA/all.js
@@ -53,6 +53,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "pesseta andorrana",

--- a/locale-tests/locales/ca-ES-VALENCIA/numbers.js
+++ b/locale-tests/locales/ca-ES-VALENCIA/numbers.js
@@ -55,6 +55,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ca-FR/all.js
+++ b/locale-tests/locales/ca-FR/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "pesseta andorrana",

--- a/locale-tests/locales/ca-FR/numbers.js
+++ b/locale-tests/locales/ca-FR/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ca-IT/all.js
+++ b/locale-tests/locales/ca-IT/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "pesseta andorrana",

--- a/locale-tests/locales/ca-IT/numbers.js
+++ b/locale-tests/locales/ca-IT/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ca/all.js
+++ b/locale-tests/locales/ca/all.js
@@ -51,6 +51,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "pesseta andorrana",

--- a/locale-tests/locales/ca/numbers.js
+++ b/locale-tests/locales/ca/numbers.js
@@ -53,6 +53,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/cs/all.js
+++ b/locale-tests/locales/cs/all.js
@@ -53,6 +53,14 @@ const data = {
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "andorrská peseta",

--- a/locale-tests/locales/cs/numbers.js
+++ b/locale-tests/locales/cs/numbers.js
@@ -55,6 +55,14 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/cy/all.js
+++ b/locale-tests/locales/cy/all.js
@@ -55,6 +55,15 @@ const data = {
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ADP",

--- a/locale-tests/locales/cy/numbers.js
+++ b/locale-tests/locales/cy/numbers.js
@@ -57,6 +57,15 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/da-GL/all.js
+++ b/locale-tests/locales/da-GL/all.js
@@ -52,6 +52,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorransk peseta",

--- a/locale-tests/locales/da-GL/numbers.js
+++ b/locale-tests/locales/da-GL/numbers.js
@@ -54,6 +54,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/da/all.js
+++ b/locale-tests/locales/da/all.js
@@ -51,6 +51,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorransk peseta",

--- a/locale-tests/locales/da/numbers.js
+++ b/locale-tests/locales/da/numbers.js
@@ -53,6 +53,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/de-AT/all.js
+++ b/locale-tests/locales/de-AT/all.js
@@ -53,6 +53,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorranische Pesete",

--- a/locale-tests/locales/de-AT/numbers.js
+++ b/locale-tests/locales/de-AT/numbers.js
@@ -55,6 +55,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/de-BE/all.js
+++ b/locale-tests/locales/de-BE/all.js
@@ -52,6 +52,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorranische Pesete",

--- a/locale-tests/locales/de-BE/numbers.js
+++ b/locale-tests/locales/de-BE/numbers.js
@@ -54,6 +54,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/de-CH/all.js
+++ b/locale-tests/locales/de-CH/all.js
@@ -53,6 +53,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorranische Pesete",

--- a/locale-tests/locales/de-CH/numbers.js
+++ b/locale-tests/locales/de-CH/numbers.js
@@ -55,6 +55,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/de-IT/all.js
+++ b/locale-tests/locales/de-IT/all.js
@@ -52,6 +52,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorranische Pesete",

--- a/locale-tests/locales/de-IT/numbers.js
+++ b/locale-tests/locales/de-IT/numbers.js
@@ -54,6 +54,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/de-LI/all.js
+++ b/locale-tests/locales/de-LI/all.js
@@ -52,6 +52,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorranische Pesete",

--- a/locale-tests/locales/de-LI/numbers.js
+++ b/locale-tests/locales/de-LI/numbers.js
@@ -54,6 +54,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/de-LU/all.js
+++ b/locale-tests/locales/de-LU/all.js
@@ -52,6 +52,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorranische Pesete",

--- a/locale-tests/locales/de-LU/numbers.js
+++ b/locale-tests/locales/de-LU/numbers.js
@@ -54,6 +54,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/de/all.js
+++ b/locale-tests/locales/de/all.js
@@ -51,6 +51,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorranische Pesete",

--- a/locale-tests/locales/de/numbers.js
+++ b/locale-tests/locales/de/numbers.js
@@ -53,6 +53,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/el-CY/all.js
+++ b/locale-tests/locales/el-CY/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Πεσέτα Ανδόρας",

--- a/locale-tests/locales/el-CY/numbers.js
+++ b/locale-tests/locales/el-CY/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/el/all.js
+++ b/locale-tests/locales/el/all.js
@@ -51,6 +51,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Πεσέτα Ανδόρας",

--- a/locale-tests/locales/el/numbers.js
+++ b/locale-tests/locales/el/numbers.js
@@ -53,6 +53,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-001/all.js
+++ b/locale-tests/locales/en-001/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-001/numbers.js
+++ b/locale-tests/locales/en-001/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-150/all.js
+++ b/locale-tests/locales/en-150/all.js
@@ -52,6 +52,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-150/numbers.js
+++ b/locale-tests/locales/en-150/numbers.js
@@ -54,6 +54,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-AG/all.js
+++ b/locale-tests/locales/en-AG/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-AG/numbers.js
+++ b/locale-tests/locales/en-AG/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-AI/all.js
+++ b/locale-tests/locales/en-AI/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-AI/numbers.js
+++ b/locale-tests/locales/en-AI/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-AS/all.js
+++ b/locale-tests/locales/en-AS/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-AS/numbers.js
+++ b/locale-tests/locales/en-AS/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-AT/all.js
+++ b/locale-tests/locales/en-AT/all.js
@@ -52,6 +52,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$ n"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-AT/numbers.js
+++ b/locale-tests/locales/en-AT/numbers.js
@@ -54,6 +54,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$ n"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-AU/all.js
+++ b/locale-tests/locales/en-AU/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-AU/numbers.js
+++ b/locale-tests/locales/en-AU/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-BB/all.js
+++ b/locale-tests/locales/en-BB/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-BB/numbers.js
+++ b/locale-tests/locales/en-BB/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-BE/all.js
+++ b/locale-tests/locales/en-BE/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-BE/numbers.js
+++ b/locale-tests/locales/en-BE/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-BI/all.js
+++ b/locale-tests/locales/en-BI/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-BI/numbers.js
+++ b/locale-tests/locales/en-BI/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-BM/all.js
+++ b/locale-tests/locales/en-BM/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-BM/numbers.js
+++ b/locale-tests/locales/en-BM/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-BS/all.js
+++ b/locale-tests/locales/en-BS/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-BS/numbers.js
+++ b/locale-tests/locales/en-BS/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-BW/all.js
+++ b/locale-tests/locales/en-BW/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-BW/numbers.js
+++ b/locale-tests/locales/en-BW/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-BZ/all.js
+++ b/locale-tests/locales/en-BZ/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-BZ/numbers.js
+++ b/locale-tests/locales/en-BZ/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-CA/all.js
+++ b/locale-tests/locales/en-CA/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-CA/numbers.js
+++ b/locale-tests/locales/en-CA/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-CC/all.js
+++ b/locale-tests/locales/en-CC/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-CC/numbers.js
+++ b/locale-tests/locales/en-CC/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-CH/all.js
+++ b/locale-tests/locales/en-CH/all.js
@@ -53,6 +53,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$ n",
+                "$-n"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-CH/numbers.js
+++ b/locale-tests/locales/en-CH/numbers.js
@@ -55,6 +55,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$ n",
+                "$-n"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-CK/all.js
+++ b/locale-tests/locales/en-CK/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-CK/numbers.js
+++ b/locale-tests/locales/en-CK/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-CM/all.js
+++ b/locale-tests/locales/en-CM/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-CM/numbers.js
+++ b/locale-tests/locales/en-CM/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-CX/all.js
+++ b/locale-tests/locales/en-CX/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-CX/numbers.js
+++ b/locale-tests/locales/en-CX/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-CY/all.js
+++ b/locale-tests/locales/en-CY/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-CY/numbers.js
+++ b/locale-tests/locales/en-CY/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-DE/all.js
+++ b/locale-tests/locales/en-DE/all.js
@@ -52,6 +52,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-DE/numbers.js
+++ b/locale-tests/locales/en-DE/numbers.js
@@ -54,6 +54,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-DG/all.js
+++ b/locale-tests/locales/en-DG/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-DG/numbers.js
+++ b/locale-tests/locales/en-DG/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-DK/all.js
+++ b/locale-tests/locales/en-DK/all.js
@@ -52,6 +52,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-DK/numbers.js
+++ b/locale-tests/locales/en-DK/numbers.js
@@ -54,6 +54,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-DM/all.js
+++ b/locale-tests/locales/en-DM/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-DM/numbers.js
+++ b/locale-tests/locales/en-DM/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-ER/all.js
+++ b/locale-tests/locales/en-ER/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-ER/numbers.js
+++ b/locale-tests/locales/en-ER/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-FI/all.js
+++ b/locale-tests/locales/en-FI/all.js
@@ -52,6 +52,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-FI/numbers.js
+++ b/locale-tests/locales/en-FI/numbers.js
@@ -54,6 +54,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-FJ/all.js
+++ b/locale-tests/locales/en-FJ/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-FJ/numbers.js
+++ b/locale-tests/locales/en-FJ/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-FK/all.js
+++ b/locale-tests/locales/en-FK/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-FK/numbers.js
+++ b/locale-tests/locales/en-FK/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-FM/all.js
+++ b/locale-tests/locales/en-FM/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-FM/numbers.js
+++ b/locale-tests/locales/en-FM/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-GB/all.js
+++ b/locale-tests/locales/en-GB/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-GB/numbers.js
+++ b/locale-tests/locales/en-GB/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-GD/all.js
+++ b/locale-tests/locales/en-GD/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-GD/numbers.js
+++ b/locale-tests/locales/en-GD/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-GG/all.js
+++ b/locale-tests/locales/en-GG/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-GG/numbers.js
+++ b/locale-tests/locales/en-GG/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-GH/all.js
+++ b/locale-tests/locales/en-GH/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-GH/numbers.js
+++ b/locale-tests/locales/en-GH/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-GI/all.js
+++ b/locale-tests/locales/en-GI/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-GI/numbers.js
+++ b/locale-tests/locales/en-GI/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-GM/all.js
+++ b/locale-tests/locales/en-GM/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-GM/numbers.js
+++ b/locale-tests/locales/en-GM/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-GU/all.js
+++ b/locale-tests/locales/en-GU/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-GU/numbers.js
+++ b/locale-tests/locales/en-GU/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-GY/all.js
+++ b/locale-tests/locales/en-GY/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-GY/numbers.js
+++ b/locale-tests/locales/en-GY/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-HK/all.js
+++ b/locale-tests/locales/en-HK/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-HK/numbers.js
+++ b/locale-tests/locales/en-HK/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-IE/all.js
+++ b/locale-tests/locales/en-IE/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-IE/numbers.js
+++ b/locale-tests/locales/en-IE/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-IL/all.js
+++ b/locale-tests/locales/en-IL/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-IL/numbers.js
+++ b/locale-tests/locales/en-IL/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-IM/all.js
+++ b/locale-tests/locales/en-IM/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-IM/numbers.js
+++ b/locale-tests/locales/en-IM/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-IN/all.js
+++ b/locale-tests/locales/en-IN/all.js
@@ -55,6 +55,16 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3,
+                2
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-IN/numbers.js
+++ b/locale-tests/locales/en-IN/numbers.js
@@ -57,6 +57,16 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3,
+                2
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-IO/all.js
+++ b/locale-tests/locales/en-IO/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-IO/numbers.js
+++ b/locale-tests/locales/en-IO/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-JE/all.js
+++ b/locale-tests/locales/en-JE/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-JE/numbers.js
+++ b/locale-tests/locales/en-JE/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-JM/all.js
+++ b/locale-tests/locales/en-JM/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-JM/numbers.js
+++ b/locale-tests/locales/en-JM/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-KE/all.js
+++ b/locale-tests/locales/en-KE/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-KE/numbers.js
+++ b/locale-tests/locales/en-KE/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-KI/all.js
+++ b/locale-tests/locales/en-KI/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-KI/numbers.js
+++ b/locale-tests/locales/en-KI/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-KN/all.js
+++ b/locale-tests/locales/en-KN/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-KN/numbers.js
+++ b/locale-tests/locales/en-KN/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-KY/all.js
+++ b/locale-tests/locales/en-KY/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-KY/numbers.js
+++ b/locale-tests/locales/en-KY/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-LC/all.js
+++ b/locale-tests/locales/en-LC/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-LC/numbers.js
+++ b/locale-tests/locales/en-LC/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-LR/all.js
+++ b/locale-tests/locales/en-LR/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-LR/numbers.js
+++ b/locale-tests/locales/en-LR/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-LS/all.js
+++ b/locale-tests/locales/en-LS/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-LS/numbers.js
+++ b/locale-tests/locales/en-LS/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-MG/all.js
+++ b/locale-tests/locales/en-MG/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-MG/numbers.js
+++ b/locale-tests/locales/en-MG/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-MH/all.js
+++ b/locale-tests/locales/en-MH/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-MH/numbers.js
+++ b/locale-tests/locales/en-MH/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-MO/all.js
+++ b/locale-tests/locales/en-MO/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-MO/numbers.js
+++ b/locale-tests/locales/en-MO/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-MP/all.js
+++ b/locale-tests/locales/en-MP/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-MP/numbers.js
+++ b/locale-tests/locales/en-MP/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-MS/all.js
+++ b/locale-tests/locales/en-MS/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-MS/numbers.js
+++ b/locale-tests/locales/en-MS/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-MT/all.js
+++ b/locale-tests/locales/en-MT/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-MT/numbers.js
+++ b/locale-tests/locales/en-MT/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-MU/all.js
+++ b/locale-tests/locales/en-MU/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-MU/numbers.js
+++ b/locale-tests/locales/en-MU/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-MW/all.js
+++ b/locale-tests/locales/en-MW/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-MW/numbers.js
+++ b/locale-tests/locales/en-MW/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-MY/all.js
+++ b/locale-tests/locales/en-MY/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-MY/numbers.js
+++ b/locale-tests/locales/en-MY/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-NA/all.js
+++ b/locale-tests/locales/en-NA/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-NA/numbers.js
+++ b/locale-tests/locales/en-NA/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-NF/all.js
+++ b/locale-tests/locales/en-NF/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-NF/numbers.js
+++ b/locale-tests/locales/en-NF/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-NG/all.js
+++ b/locale-tests/locales/en-NG/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-NG/numbers.js
+++ b/locale-tests/locales/en-NG/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-NL/all.js
+++ b/locale-tests/locales/en-NL/all.js
@@ -53,6 +53,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$ n",
+                "($ n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-NL/numbers.js
+++ b/locale-tests/locales/en-NL/numbers.js
@@ -55,6 +55,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$ n",
+                "($ n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-NR/all.js
+++ b/locale-tests/locales/en-NR/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-NR/numbers.js
+++ b/locale-tests/locales/en-NR/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-NU/all.js
+++ b/locale-tests/locales/en-NU/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-NU/numbers.js
+++ b/locale-tests/locales/en-NU/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-NZ/all.js
+++ b/locale-tests/locales/en-NZ/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-NZ/numbers.js
+++ b/locale-tests/locales/en-NZ/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-PG/all.js
+++ b/locale-tests/locales/en-PG/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-PG/numbers.js
+++ b/locale-tests/locales/en-PG/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-PH/all.js
+++ b/locale-tests/locales/en-PH/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-PH/numbers.js
+++ b/locale-tests/locales/en-PH/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-PK/all.js
+++ b/locale-tests/locales/en-PK/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-PK/numbers.js
+++ b/locale-tests/locales/en-PK/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-PN/all.js
+++ b/locale-tests/locales/en-PN/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-PN/numbers.js
+++ b/locale-tests/locales/en-PN/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-PR/all.js
+++ b/locale-tests/locales/en-PR/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-PR/numbers.js
+++ b/locale-tests/locales/en-PR/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-PW/all.js
+++ b/locale-tests/locales/en-PW/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-PW/numbers.js
+++ b/locale-tests/locales/en-PW/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-RW/all.js
+++ b/locale-tests/locales/en-RW/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-RW/numbers.js
+++ b/locale-tests/locales/en-RW/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-SB/all.js
+++ b/locale-tests/locales/en-SB/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-SB/numbers.js
+++ b/locale-tests/locales/en-SB/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-SC/all.js
+++ b/locale-tests/locales/en-SC/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-SC/numbers.js
+++ b/locale-tests/locales/en-SC/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-SD/all.js
+++ b/locale-tests/locales/en-SD/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-SD/numbers.js
+++ b/locale-tests/locales/en-SD/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-SE/all.js
+++ b/locale-tests/locales/en-SE/all.js
@@ -52,6 +52,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-SE/numbers.js
+++ b/locale-tests/locales/en-SE/numbers.js
@@ -54,6 +54,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-SG/all.js
+++ b/locale-tests/locales/en-SG/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-SG/numbers.js
+++ b/locale-tests/locales/en-SG/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-SH/all.js
+++ b/locale-tests/locales/en-SH/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-SH/numbers.js
+++ b/locale-tests/locales/en-SH/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-SI/all.js
+++ b/locale-tests/locales/en-SI/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-SI/numbers.js
+++ b/locale-tests/locales/en-SI/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-SL/all.js
+++ b/locale-tests/locales/en-SL/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-SL/numbers.js
+++ b/locale-tests/locales/en-SL/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-SS/all.js
+++ b/locale-tests/locales/en-SS/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-SS/numbers.js
+++ b/locale-tests/locales/en-SS/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-SX/all.js
+++ b/locale-tests/locales/en-SX/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-SX/numbers.js
+++ b/locale-tests/locales/en-SX/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-SZ/all.js
+++ b/locale-tests/locales/en-SZ/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-SZ/numbers.js
+++ b/locale-tests/locales/en-SZ/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-TC/all.js
+++ b/locale-tests/locales/en-TC/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-TC/numbers.js
+++ b/locale-tests/locales/en-TC/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-TK/all.js
+++ b/locale-tests/locales/en-TK/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-TK/numbers.js
+++ b/locale-tests/locales/en-TK/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-TO/all.js
+++ b/locale-tests/locales/en-TO/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-TO/numbers.js
+++ b/locale-tests/locales/en-TO/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-TT/all.js
+++ b/locale-tests/locales/en-TT/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-TT/numbers.js
+++ b/locale-tests/locales/en-TT/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-TV/all.js
+++ b/locale-tests/locales/en-TV/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-TV/numbers.js
+++ b/locale-tests/locales/en-TV/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-TZ/all.js
+++ b/locale-tests/locales/en-TZ/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-TZ/numbers.js
+++ b/locale-tests/locales/en-TZ/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-UG/all.js
+++ b/locale-tests/locales/en-UG/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-UG/numbers.js
+++ b/locale-tests/locales/en-UG/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-UM/all.js
+++ b/locale-tests/locales/en-UM/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-UM/numbers.js
+++ b/locale-tests/locales/en-UM/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-US-POSIX/all.js
+++ b/locale-tests/locales/en-US-POSIX/all.js
@@ -47,6 +47,13 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: []
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-US-POSIX/numbers.js
+++ b/locale-tests/locales/en-US-POSIX/numbers.js
@@ -49,6 +49,13 @@ const data = {
             groupSize: [],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: []
         }
     }
 };

--- a/locale-tests/locales/en-VC/all.js
+++ b/locale-tests/locales/en-VC/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-VC/numbers.js
+++ b/locale-tests/locales/en-VC/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-VG/all.js
+++ b/locale-tests/locales/en-VG/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-VG/numbers.js
+++ b/locale-tests/locales/en-VG/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-VI/all.js
+++ b/locale-tests/locales/en-VI/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-VI/numbers.js
+++ b/locale-tests/locales/en-VI/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-VU/all.js
+++ b/locale-tests/locales/en-VU/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-VU/numbers.js
+++ b/locale-tests/locales/en-VU/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-WS/all.js
+++ b/locale-tests/locales/en-WS/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-WS/numbers.js
+++ b/locale-tests/locales/en-WS/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-ZA/all.js
+++ b/locale-tests/locales/en-ZA/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-ZA/numbers.js
+++ b/locale-tests/locales/en-ZA/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-ZM/all.js
+++ b/locale-tests/locales/en-ZM/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-ZM/numbers.js
+++ b/locale-tests/locales/en-ZM/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en-ZW/all.js
+++ b/locale-tests/locales/en-ZW/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran Peseta",

--- a/locale-tests/locales/en-ZW/numbers.js
+++ b/locale-tests/locales/en-ZW/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/en/all.js
+++ b/locale-tests/locales/en/all.js
@@ -1935,7 +1935,16 @@ const data = {
                 symbol: "ZWR"
             }
         },
-        localeCurrency: "USD"
+        localeCurrency: "USD",
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        }
     },
     calendar: {
         gmtFormat: "GMT{0}",

--- a/locale-tests/locales/en/numbers.js
+++ b/locale-tests/locales/en/numbers.js
@@ -53,6 +53,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/es-419/all.js
+++ b/locale-tests/locales/es-419/all.js
@@ -52,6 +52,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrana",

--- a/locale-tests/locales/es-419/numbers.js
+++ b/locale-tests/locales/es-419/numbers.js
@@ -54,6 +54,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/es-AR/all.js
+++ b/locale-tests/locales/es-AR/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$ n",
+                "($ n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrana",

--- a/locale-tests/locales/es-AR/numbers.js
+++ b/locale-tests/locales/es-AR/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$ n",
+                "($ n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/es-BO/all.js
+++ b/locale-tests/locales/es-BO/all.js
@@ -52,6 +52,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrana",

--- a/locale-tests/locales/es-BO/numbers.js
+++ b/locale-tests/locales/es-BO/numbers.js
@@ -54,6 +54,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/es-BR/all.js
+++ b/locale-tests/locales/es-BR/all.js
@@ -52,6 +52,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrana",

--- a/locale-tests/locales/es-BR/numbers.js
+++ b/locale-tests/locales/es-BR/numbers.js
@@ -54,6 +54,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/es-BZ/all.js
+++ b/locale-tests/locales/es-BZ/all.js
@@ -52,6 +52,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrana",

--- a/locale-tests/locales/es-BZ/numbers.js
+++ b/locale-tests/locales/es-BZ/numbers.js
@@ -54,6 +54,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/es-CL/all.js
+++ b/locale-tests/locales/es-CL/all.js
@@ -53,6 +53,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrana",

--- a/locale-tests/locales/es-CL/numbers.js
+++ b/locale-tests/locales/es-CL/numbers.js
@@ -55,6 +55,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/es-CO/all.js
+++ b/locale-tests/locales/es-CO/all.js
@@ -52,6 +52,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrana",

--- a/locale-tests/locales/es-CO/numbers.js
+++ b/locale-tests/locales/es-CO/numbers.js
@@ -54,6 +54,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/es-CR/all.js
+++ b/locale-tests/locales/es-CR/all.js
@@ -52,6 +52,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrana",

--- a/locale-tests/locales/es-CR/numbers.js
+++ b/locale-tests/locales/es-CR/numbers.js
@@ -54,6 +54,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/es-CU/all.js
+++ b/locale-tests/locales/es-CU/all.js
@@ -52,6 +52,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrana",

--- a/locale-tests/locales/es-CU/numbers.js
+++ b/locale-tests/locales/es-CU/numbers.js
@@ -54,6 +54,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/es-DO/all.js
+++ b/locale-tests/locales/es-DO/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrana",

--- a/locale-tests/locales/es-DO/numbers.js
+++ b/locale-tests/locales/es-DO/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/es-EA/all.js
+++ b/locale-tests/locales/es-EA/all.js
@@ -52,6 +52,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrana",

--- a/locale-tests/locales/es-EA/numbers.js
+++ b/locale-tests/locales/es-EA/numbers.js
@@ -54,6 +54,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/es-EC/all.js
+++ b/locale-tests/locales/es-EC/all.js
@@ -53,6 +53,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrana",

--- a/locale-tests/locales/es-EC/numbers.js
+++ b/locale-tests/locales/es-EC/numbers.js
@@ -55,6 +55,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/es-GQ/all.js
+++ b/locale-tests/locales/es-GQ/all.js
@@ -52,6 +52,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrana",

--- a/locale-tests/locales/es-GQ/numbers.js
+++ b/locale-tests/locales/es-GQ/numbers.js
@@ -54,6 +54,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/es-GT/all.js
+++ b/locale-tests/locales/es-GT/all.js
@@ -52,6 +52,14 @@ const data = {
             "unitPattern-count-one": "$ n",
             "unitPattern-count-other": "$ n"
         },
+        accounting: {
+            patterns: [
+                "$n"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrana",

--- a/locale-tests/locales/es-GT/numbers.js
+++ b/locale-tests/locales/es-GT/numbers.js
@@ -54,6 +54,14 @@ const data = {
             ],
             "unitPattern-count-one": "$ n",
             "unitPattern-count-other": "$ n"
+        },
+        accounting: {
+            patterns: [
+                "$n"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/es-HN/all.js
+++ b/locale-tests/locales/es-HN/all.js
@@ -52,6 +52,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrana",

--- a/locale-tests/locales/es-HN/numbers.js
+++ b/locale-tests/locales/es-HN/numbers.js
@@ -54,6 +54,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/es-IC/all.js
+++ b/locale-tests/locales/es-IC/all.js
@@ -52,6 +52,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrana",

--- a/locale-tests/locales/es-IC/numbers.js
+++ b/locale-tests/locales/es-IC/numbers.js
@@ -54,6 +54,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/es-MX/all.js
+++ b/locale-tests/locales/es-MX/all.js
@@ -52,6 +52,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrana",

--- a/locale-tests/locales/es-MX/numbers.js
+++ b/locale-tests/locales/es-MX/numbers.js
@@ -54,6 +54,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/es-NI/all.js
+++ b/locale-tests/locales/es-NI/all.js
@@ -52,6 +52,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrana",

--- a/locale-tests/locales/es-NI/numbers.js
+++ b/locale-tests/locales/es-NI/numbers.js
@@ -54,6 +54,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/es-PA/all.js
+++ b/locale-tests/locales/es-PA/all.js
@@ -52,6 +52,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrana",

--- a/locale-tests/locales/es-PA/numbers.js
+++ b/locale-tests/locales/es-PA/numbers.js
@@ -54,6 +54,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/es-PE/all.js
+++ b/locale-tests/locales/es-PE/all.js
@@ -52,6 +52,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrana",

--- a/locale-tests/locales/es-PE/numbers.js
+++ b/locale-tests/locales/es-PE/numbers.js
@@ -54,6 +54,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/es-PH/all.js
+++ b/locale-tests/locales/es-PH/all.js
@@ -52,6 +52,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrana",

--- a/locale-tests/locales/es-PH/numbers.js
+++ b/locale-tests/locales/es-PH/numbers.js
@@ -54,6 +54,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/es-PR/all.js
+++ b/locale-tests/locales/es-PR/all.js
@@ -52,6 +52,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrana",

--- a/locale-tests/locales/es-PR/numbers.js
+++ b/locale-tests/locales/es-PR/numbers.js
@@ -54,6 +54,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/es-PY/all.js
+++ b/locale-tests/locales/es-PY/all.js
@@ -53,6 +53,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrana",

--- a/locale-tests/locales/es-PY/numbers.js
+++ b/locale-tests/locales/es-PY/numbers.js
@@ -55,6 +55,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/es-SV/all.js
+++ b/locale-tests/locales/es-SV/all.js
@@ -52,6 +52,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrana",

--- a/locale-tests/locales/es-SV/numbers.js
+++ b/locale-tests/locales/es-SV/numbers.js
@@ -54,6 +54,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/es-US/all.js
+++ b/locale-tests/locales/es-US/all.js
@@ -52,6 +52,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrana",

--- a/locale-tests/locales/es-US/numbers.js
+++ b/locale-tests/locales/es-US/numbers.js
@@ -54,6 +54,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/es-UY/all.js
+++ b/locale-tests/locales/es-UY/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$ n",
+                "($ n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrana",

--- a/locale-tests/locales/es-UY/numbers.js
+++ b/locale-tests/locales/es-UY/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$ n",
+                "($ n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/es-VE/all.js
+++ b/locale-tests/locales/es-VE/all.js
@@ -53,6 +53,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrana",

--- a/locale-tests/locales/es-VE/numbers.js
+++ b/locale-tests/locales/es-VE/numbers.js
@@ -55,6 +55,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/es/all.js
+++ b/locale-tests/locales/es/all.js
@@ -51,6 +51,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrana",

--- a/locale-tests/locales/es/numbers.js
+++ b/locale-tests/locales/es/numbers.js
@@ -53,6 +53,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/et/all.js
+++ b/locale-tests/locales/et/all.js
@@ -51,6 +51,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorra peseeta",

--- a/locale-tests/locales/et/numbers.js
+++ b/locale-tests/locales/et/numbers.js
@@ -53,6 +53,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/eu/all.js
+++ b/locale-tests/locales/eu/all.js
@@ -51,6 +51,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ADP",

--- a/locale-tests/locales/eu/numbers.js
+++ b/locale-tests/locales/eu/numbers.js
@@ -53,6 +53,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fa-AF/all.js
+++ b/locale-tests/locales/fa-AF/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$ n",
+                "‎($ n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "پزتای آندورا",

--- a/locale-tests/locales/fa-AF/numbers.js
+++ b/locale-tests/locales/fa-AF/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$ n",
+                "‎($ n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fa/all.js
+++ b/locale-tests/locales/fa/all.js
@@ -51,6 +51,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "‎$ n",
+                "‎($ n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "پزتای آندورا",

--- a/locale-tests/locales/fa/numbers.js
+++ b/locale-tests/locales/fa/numbers.js
@@ -53,6 +53,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "‎$ n",
+                "‎($ n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fi/all.js
+++ b/locale-tests/locales/fi/all.js
@@ -51,6 +51,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorran peseta",

--- a/locale-tests/locales/fi/numbers.js
+++ b/locale-tests/locales/fi/numbers.js
@@ -53,6 +53,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fil/all.js
+++ b/locale-tests/locales/fil/all.js
@@ -51,6 +51,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ADP",

--- a/locale-tests/locales/fil/numbers.js
+++ b/locale-tests/locales/fil/numbers.js
@@ -53,6 +53,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fo-DK/all.js
+++ b/locale-tests/locales/fo-DK/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ADP",

--- a/locale-tests/locales/fo-DK/numbers.js
+++ b/locale-tests/locales/fo-DK/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fo/all.js
+++ b/locale-tests/locales/fo/all.js
@@ -51,6 +51,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ADP",

--- a/locale-tests/locales/fo/numbers.js
+++ b/locale-tests/locales/fo/numbers.js
@@ -53,6 +53,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fr-BE/all.js
+++ b/locale-tests/locales/fr-BE/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrane",

--- a/locale-tests/locales/fr-BE/numbers.js
+++ b/locale-tests/locales/fr-BE/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fr-BF/all.js
+++ b/locale-tests/locales/fr-BF/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrane",

--- a/locale-tests/locales/fr-BF/numbers.js
+++ b/locale-tests/locales/fr-BF/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fr-BI/all.js
+++ b/locale-tests/locales/fr-BI/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrane",

--- a/locale-tests/locales/fr-BI/numbers.js
+++ b/locale-tests/locales/fr-BI/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fr-BJ/all.js
+++ b/locale-tests/locales/fr-BJ/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrane",

--- a/locale-tests/locales/fr-BJ/numbers.js
+++ b/locale-tests/locales/fr-BJ/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fr-BL/all.js
+++ b/locale-tests/locales/fr-BL/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrane",

--- a/locale-tests/locales/fr-BL/numbers.js
+++ b/locale-tests/locales/fr-BL/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fr-CA/all.js
+++ b/locale-tests/locales/fr-CA/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrane",

--- a/locale-tests/locales/fr-CA/numbers.js
+++ b/locale-tests/locales/fr-CA/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fr-CD/all.js
+++ b/locale-tests/locales/fr-CD/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrane",

--- a/locale-tests/locales/fr-CD/numbers.js
+++ b/locale-tests/locales/fr-CD/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fr-CF/all.js
+++ b/locale-tests/locales/fr-CF/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrane",

--- a/locale-tests/locales/fr-CF/numbers.js
+++ b/locale-tests/locales/fr-CF/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fr-CG/all.js
+++ b/locale-tests/locales/fr-CG/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrane",

--- a/locale-tests/locales/fr-CG/numbers.js
+++ b/locale-tests/locales/fr-CG/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fr-CH/all.js
+++ b/locale-tests/locales/fr-CH/all.js
@@ -53,6 +53,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrane",

--- a/locale-tests/locales/fr-CH/numbers.js
+++ b/locale-tests/locales/fr-CH/numbers.js
@@ -55,6 +55,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fr-CI/all.js
+++ b/locale-tests/locales/fr-CI/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrane",

--- a/locale-tests/locales/fr-CI/numbers.js
+++ b/locale-tests/locales/fr-CI/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fr-CM/all.js
+++ b/locale-tests/locales/fr-CM/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrane",

--- a/locale-tests/locales/fr-CM/numbers.js
+++ b/locale-tests/locales/fr-CM/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fr-DJ/all.js
+++ b/locale-tests/locales/fr-DJ/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrane",

--- a/locale-tests/locales/fr-DJ/numbers.js
+++ b/locale-tests/locales/fr-DJ/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fr-DZ/all.js
+++ b/locale-tests/locales/fr-DZ/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrane",

--- a/locale-tests/locales/fr-DZ/numbers.js
+++ b/locale-tests/locales/fr-DZ/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fr-GA/all.js
+++ b/locale-tests/locales/fr-GA/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrane",

--- a/locale-tests/locales/fr-GA/numbers.js
+++ b/locale-tests/locales/fr-GA/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fr-GF/all.js
+++ b/locale-tests/locales/fr-GF/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrane",

--- a/locale-tests/locales/fr-GF/numbers.js
+++ b/locale-tests/locales/fr-GF/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fr-GN/all.js
+++ b/locale-tests/locales/fr-GN/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrane",

--- a/locale-tests/locales/fr-GN/numbers.js
+++ b/locale-tests/locales/fr-GN/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fr-GP/all.js
+++ b/locale-tests/locales/fr-GP/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrane",

--- a/locale-tests/locales/fr-GP/numbers.js
+++ b/locale-tests/locales/fr-GP/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fr-GQ/all.js
+++ b/locale-tests/locales/fr-GQ/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrane",

--- a/locale-tests/locales/fr-GQ/numbers.js
+++ b/locale-tests/locales/fr-GQ/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fr-HT/all.js
+++ b/locale-tests/locales/fr-HT/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrane",

--- a/locale-tests/locales/fr-HT/numbers.js
+++ b/locale-tests/locales/fr-HT/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fr-KM/all.js
+++ b/locale-tests/locales/fr-KM/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrane",

--- a/locale-tests/locales/fr-KM/numbers.js
+++ b/locale-tests/locales/fr-KM/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fr-LU/all.js
+++ b/locale-tests/locales/fr-LU/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrane",

--- a/locale-tests/locales/fr-LU/numbers.js
+++ b/locale-tests/locales/fr-LU/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fr-MA/all.js
+++ b/locale-tests/locales/fr-MA/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrane",

--- a/locale-tests/locales/fr-MA/numbers.js
+++ b/locale-tests/locales/fr-MA/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fr-MC/all.js
+++ b/locale-tests/locales/fr-MC/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrane",

--- a/locale-tests/locales/fr-MC/numbers.js
+++ b/locale-tests/locales/fr-MC/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fr-MF/all.js
+++ b/locale-tests/locales/fr-MF/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrane",

--- a/locale-tests/locales/fr-MF/numbers.js
+++ b/locale-tests/locales/fr-MF/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fr-MG/all.js
+++ b/locale-tests/locales/fr-MG/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrane",

--- a/locale-tests/locales/fr-MG/numbers.js
+++ b/locale-tests/locales/fr-MG/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fr-ML/all.js
+++ b/locale-tests/locales/fr-ML/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrane",

--- a/locale-tests/locales/fr-ML/numbers.js
+++ b/locale-tests/locales/fr-ML/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fr-MQ/all.js
+++ b/locale-tests/locales/fr-MQ/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrane",

--- a/locale-tests/locales/fr-MQ/numbers.js
+++ b/locale-tests/locales/fr-MQ/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fr-MR/all.js
+++ b/locale-tests/locales/fr-MR/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrane",

--- a/locale-tests/locales/fr-MR/numbers.js
+++ b/locale-tests/locales/fr-MR/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fr-MU/all.js
+++ b/locale-tests/locales/fr-MU/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrane",

--- a/locale-tests/locales/fr-MU/numbers.js
+++ b/locale-tests/locales/fr-MU/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fr-NC/all.js
+++ b/locale-tests/locales/fr-NC/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrane",

--- a/locale-tests/locales/fr-NC/numbers.js
+++ b/locale-tests/locales/fr-NC/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fr-NE/all.js
+++ b/locale-tests/locales/fr-NE/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrane",

--- a/locale-tests/locales/fr-NE/numbers.js
+++ b/locale-tests/locales/fr-NE/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fr-PF/all.js
+++ b/locale-tests/locales/fr-PF/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrane",

--- a/locale-tests/locales/fr-PF/numbers.js
+++ b/locale-tests/locales/fr-PF/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fr-PM/all.js
+++ b/locale-tests/locales/fr-PM/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrane",

--- a/locale-tests/locales/fr-PM/numbers.js
+++ b/locale-tests/locales/fr-PM/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fr-RE/all.js
+++ b/locale-tests/locales/fr-RE/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrane",

--- a/locale-tests/locales/fr-RE/numbers.js
+++ b/locale-tests/locales/fr-RE/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fr-RW/all.js
+++ b/locale-tests/locales/fr-RW/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrane",

--- a/locale-tests/locales/fr-RW/numbers.js
+++ b/locale-tests/locales/fr-RW/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fr-SC/all.js
+++ b/locale-tests/locales/fr-SC/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrane",

--- a/locale-tests/locales/fr-SC/numbers.js
+++ b/locale-tests/locales/fr-SC/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fr-SN/all.js
+++ b/locale-tests/locales/fr-SN/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrane",

--- a/locale-tests/locales/fr-SN/numbers.js
+++ b/locale-tests/locales/fr-SN/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fr-SY/all.js
+++ b/locale-tests/locales/fr-SY/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrane",

--- a/locale-tests/locales/fr-SY/numbers.js
+++ b/locale-tests/locales/fr-SY/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fr-TD/all.js
+++ b/locale-tests/locales/fr-TD/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrane",

--- a/locale-tests/locales/fr-TD/numbers.js
+++ b/locale-tests/locales/fr-TD/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fr-TG/all.js
+++ b/locale-tests/locales/fr-TG/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrane",

--- a/locale-tests/locales/fr-TG/numbers.js
+++ b/locale-tests/locales/fr-TG/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fr-TN/all.js
+++ b/locale-tests/locales/fr-TN/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrane",

--- a/locale-tests/locales/fr-TN/numbers.js
+++ b/locale-tests/locales/fr-TN/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fr-VU/all.js
+++ b/locale-tests/locales/fr-VU/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrane",

--- a/locale-tests/locales/fr-VU/numbers.js
+++ b/locale-tests/locales/fr-VU/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fr-WF/all.js
+++ b/locale-tests/locales/fr-WF/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrane",

--- a/locale-tests/locales/fr-WF/numbers.js
+++ b/locale-tests/locales/fr-WF/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fr-YT/all.js
+++ b/locale-tests/locales/fr-YT/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrane",

--- a/locale-tests/locales/fr-YT/numbers.js
+++ b/locale-tests/locales/fr-YT/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/fr/all.js
+++ b/locale-tests/locales/fr/all.js
@@ -51,6 +51,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrane",

--- a/locale-tests/locales/fr/numbers.js
+++ b/locale-tests/locales/fr/numbers.js
@@ -53,6 +53,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ga/all.js
+++ b/locale-tests/locales/ga/all.js
@@ -54,6 +54,15 @@ const data = {
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Peseta Andóra",

--- a/locale-tests/locales/ga/numbers.js
+++ b/locale-tests/locales/ga/numbers.js
@@ -56,6 +56,15 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/gl/all.js
+++ b/locale-tests/locales/gl/all.js
@@ -51,6 +51,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrana",

--- a/locale-tests/locales/gl/numbers.js
+++ b/locale-tests/locales/gl/numbers.js
@@ -53,6 +53,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/gu/all.js
+++ b/locale-tests/locales/gu/all.js
@@ -54,6 +54,16 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3,
+                2
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ADP",

--- a/locale-tests/locales/gu/numbers.js
+++ b/locale-tests/locales/gu/numbers.js
@@ -56,6 +56,16 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3,
+                2
+            ]
         }
     }
 };

--- a/locale-tests/locales/he/all.js
+++ b/locale-tests/locales/he/all.js
@@ -54,6 +54,14 @@ const data = {
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "פזטה אנדורית",

--- a/locale-tests/locales/he/numbers.js
+++ b/locale-tests/locales/he/numbers.js
@@ -56,6 +56,14 @@ const data = {
             "unitPattern-count-two": "n $",
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/hi/all.js
+++ b/locale-tests/locales/hi/all.js
@@ -54,6 +54,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n"
+            ],
+            groupSize: [
+                3,
+                2
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ADP",

--- a/locale-tests/locales/hi/numbers.js
+++ b/locale-tests/locales/hi/numbers.js
@@ -56,6 +56,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n"
+            ],
+            groupSize: [
+                3,
+                2
+            ]
         }
     }
 };

--- a/locale-tests/locales/hr-BA/all.js
+++ b/locale-tests/locales/hr-BA/all.js
@@ -53,6 +53,14 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "andorska pezeta",

--- a/locale-tests/locales/hr-BA/numbers.js
+++ b/locale-tests/locales/hr-BA/numbers.js
@@ -55,6 +55,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-few": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/hr/all.js
+++ b/locale-tests/locales/hr/all.js
@@ -52,6 +52,14 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "andorska pezeta",

--- a/locale-tests/locales/hr/numbers.js
+++ b/locale-tests/locales/hr/numbers.js
@@ -54,6 +54,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-few": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/hu/all.js
+++ b/locale-tests/locales/hu/all.js
@@ -51,6 +51,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorrai peseta",

--- a/locale-tests/locales/hu/numbers.js
+++ b/locale-tests/locales/hu/numbers.js
@@ -53,6 +53,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/hy/all.js
+++ b/locale-tests/locales/hy/all.js
@@ -51,6 +51,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$ n"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ADP",

--- a/locale-tests/locales/hy/numbers.js
+++ b/locale-tests/locales/hy/numbers.js
@@ -53,6 +53,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$ n"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/id/all.js
+++ b/locale-tests/locales/id/all.js
@@ -50,6 +50,14 @@ const data = {
             ],
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Peseta Andorra",

--- a/locale-tests/locales/id/numbers.js
+++ b/locale-tests/locales/id/numbers.js
@@ -52,6 +52,14 @@ const data = {
                 3
             ],
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/is/all.js
+++ b/locale-tests/locales/is/all.js
@@ -51,6 +51,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorrskur peseti",

--- a/locale-tests/locales/is/numbers.js
+++ b/locale-tests/locales/is/numbers.js
@@ -53,6 +53,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/it-CH/all.js
+++ b/locale-tests/locales/it-CH/all.js
@@ -53,6 +53,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrana",

--- a/locale-tests/locales/it-CH/numbers.js
+++ b/locale-tests/locales/it-CH/numbers.js
@@ -55,6 +55,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/it-SM/all.js
+++ b/locale-tests/locales/it-SM/all.js
@@ -52,6 +52,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrana",

--- a/locale-tests/locales/it-SM/numbers.js
+++ b/locale-tests/locales/it-SM/numbers.js
@@ -54,6 +54,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/it-VA/all.js
+++ b/locale-tests/locales/it-VA/all.js
@@ -52,6 +52,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrana",

--- a/locale-tests/locales/it-VA/numbers.js
+++ b/locale-tests/locales/it-VA/numbers.js
@@ -54,6 +54,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/it/all.js
+++ b/locale-tests/locales/it/all.js
@@ -51,6 +51,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorrana",

--- a/locale-tests/locales/it/numbers.js
+++ b/locale-tests/locales/it/numbers.js
@@ -53,6 +53,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ja/all.js
+++ b/locale-tests/locales/ja/all.js
@@ -50,6 +50,15 @@ const data = {
             ],
             "unitPattern-count-other": "n$"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "アンドラ ペセタ",

--- a/locale-tests/locales/ja/numbers.js
+++ b/locale-tests/locales/ja/numbers.js
@@ -52,6 +52,15 @@ const data = {
                 3
             ],
             "unitPattern-count-other": "n$"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ka/all.js
+++ b/locale-tests/locales/ka/all.js
@@ -51,6 +51,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ანდორული პესეტა",

--- a/locale-tests/locales/ka/numbers.js
+++ b/locale-tests/locales/ka/numbers.js
@@ -53,6 +53,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/kk/all.js
+++ b/locale-tests/locales/kk/all.js
@@ -51,6 +51,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ADP",

--- a/locale-tests/locales/kk/numbers.js
+++ b/locale-tests/locales/kk/numbers.js
@@ -53,6 +53,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/km/all.js
+++ b/locale-tests/locales/km/all.js
@@ -50,6 +50,15 @@ const data = {
             ],
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n$",
+                "(n$)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ADP",

--- a/locale-tests/locales/km/numbers.js
+++ b/locale-tests/locales/km/numbers.js
@@ -52,6 +52,15 @@ const data = {
                 3
             ],
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n$",
+                "(n$)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/kn/all.js
+++ b/locale-tests/locales/kn/all.js
@@ -51,6 +51,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ADP",

--- a/locale-tests/locales/kn/numbers.js
+++ b/locale-tests/locales/kn/numbers.js
@@ -53,6 +53,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ko-KP/all.js
+++ b/locale-tests/locales/ko-KP/all.js
@@ -51,6 +51,15 @@ const data = {
             ],
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "안도라 페세타",

--- a/locale-tests/locales/ko-KP/numbers.js
+++ b/locale-tests/locales/ko-KP/numbers.js
@@ -53,6 +53,15 @@ const data = {
                 3
             ],
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ko/all.js
+++ b/locale-tests/locales/ko/all.js
@@ -50,6 +50,15 @@ const data = {
             ],
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "안도라 페세타",

--- a/locale-tests/locales/ko/numbers.js
+++ b/locale-tests/locales/ko/numbers.js
@@ -52,6 +52,15 @@ const data = {
                 3
             ],
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ky/all.js
+++ b/locale-tests/locales/ky/all.js
@@ -51,6 +51,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ADP",

--- a/locale-tests/locales/ky/numbers.js
+++ b/locale-tests/locales/ky/numbers.js
@@ -53,6 +53,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/lo/all.js
+++ b/locale-tests/locales/lo/all.js
@@ -51,6 +51,15 @@ const data = {
             ],
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "$-n"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ເປເຊຕາ ອັນໂດລາ",

--- a/locale-tests/locales/lo/numbers.js
+++ b/locale-tests/locales/lo/numbers.js
@@ -53,6 +53,15 @@ const data = {
                 3
             ],
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "$-n"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/lt/all.js
+++ b/locale-tests/locales/lt/all.js
@@ -53,6 +53,14 @@ const data = {
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andoros peseta",

--- a/locale-tests/locales/lt/numbers.js
+++ b/locale-tests/locales/lt/numbers.js
@@ -55,6 +55,14 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/lv/all.js
+++ b/locale-tests/locales/lv/all.js
@@ -52,6 +52,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ADP",

--- a/locale-tests/locales/lv/numbers.js
+++ b/locale-tests/locales/lv/numbers.js
@@ -54,6 +54,14 @@ const data = {
             "unitPattern-count-zero": "n $",
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/mk/all.js
+++ b/locale-tests/locales/mk/all.js
@@ -51,6 +51,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Андорска Пезета",

--- a/locale-tests/locales/mk/numbers.js
+++ b/locale-tests/locales/mk/numbers.js
@@ -53,6 +53,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ml/all.js
+++ b/locale-tests/locales/ml/all.js
@@ -53,6 +53,16 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3,
+                2
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "അൻഡോറൻ പെസെയ്റ്റ",

--- a/locale-tests/locales/ml/numbers.js
+++ b/locale-tests/locales/ml/numbers.js
@@ -55,6 +55,16 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3,
+                2
+            ]
         }
     }
 };

--- a/locale-tests/locales/mn/all.js
+++ b/locale-tests/locales/mn/all.js
@@ -51,6 +51,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$ n"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ADP",

--- a/locale-tests/locales/mn/numbers.js
+++ b/locale-tests/locales/mn/numbers.js
@@ -53,6 +53,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$ n"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/mr/all.js
+++ b/locale-tests/locales/mr/all.js
@@ -53,6 +53,16 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3,
+                2
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ADP",

--- a/locale-tests/locales/mr/numbers.js
+++ b/locale-tests/locales/mr/numbers.js
@@ -55,6 +55,16 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3,
+                2
+            ]
         }
     }
 };

--- a/locale-tests/locales/ms-BN/all.js
+++ b/locale-tests/locales/ms-BN/all.js
@@ -51,6 +51,15 @@ const data = {
             ],
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ADP",

--- a/locale-tests/locales/ms-BN/numbers.js
+++ b/locale-tests/locales/ms-BN/numbers.js
@@ -53,6 +53,15 @@ const data = {
                 3
             ],
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ms-SG/all.js
+++ b/locale-tests/locales/ms-SG/all.js
@@ -51,6 +51,15 @@ const data = {
             ],
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ADP",

--- a/locale-tests/locales/ms-SG/numbers.js
+++ b/locale-tests/locales/ms-SG/numbers.js
@@ -53,6 +53,15 @@ const data = {
                 3
             ],
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ms/all.js
+++ b/locale-tests/locales/ms/all.js
@@ -50,6 +50,15 @@ const data = {
             ],
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ADP",

--- a/locale-tests/locales/ms/numbers.js
+++ b/locale-tests/locales/ms/numbers.js
@@ -52,6 +52,15 @@ const data = {
                 3
             ],
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/my/all.js
+++ b/locale-tests/locales/my/all.js
@@ -50,6 +50,14 @@ const data = {
             ],
             "unitPattern-count-other": "$ n"
         },
+        accounting: {
+            patterns: [
+                "$ n"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ADP",

--- a/locale-tests/locales/my/numbers.js
+++ b/locale-tests/locales/my/numbers.js
@@ -52,6 +52,14 @@ const data = {
                 3
             ],
             "unitPattern-count-other": "$ n"
+        },
+        accounting: {
+            patterns: [
+                "$ n"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/nb-SJ/all.js
+++ b/locale-tests/locales/nb-SJ/all.js
@@ -53,6 +53,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$ n"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "andorranske pesetas",

--- a/locale-tests/locales/nb-SJ/numbers.js
+++ b/locale-tests/locales/nb-SJ/numbers.js
@@ -55,6 +55,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$ n"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/nb/all.js
+++ b/locale-tests/locales/nb/all.js
@@ -52,6 +52,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$ n"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "andorranske pesetas",

--- a/locale-tests/locales/nb/numbers.js
+++ b/locale-tests/locales/nb/numbers.js
@@ -54,6 +54,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$ n"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ne-IN/all.js
+++ b/locale-tests/locales/ne-IN/all.js
@@ -52,6 +52,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$ n"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ADP",

--- a/locale-tests/locales/ne-IN/numbers.js
+++ b/locale-tests/locales/ne-IN/numbers.js
@@ -54,6 +54,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$ n"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ne/all.js
+++ b/locale-tests/locales/ne/all.js
@@ -51,6 +51,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$ n"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ADP",

--- a/locale-tests/locales/ne/numbers.js
+++ b/locale-tests/locales/ne/numbers.js
@@ -53,6 +53,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$ n"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/nl-AW/all.js
+++ b/locale-tests/locales/nl-AW/all.js
@@ -53,6 +53,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$ n",
+                "($ n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorrese peseta",

--- a/locale-tests/locales/nl-AW/numbers.js
+++ b/locale-tests/locales/nl-AW/numbers.js
@@ -55,6 +55,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$ n",
+                "($ n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/nl-BE/all.js
+++ b/locale-tests/locales/nl-BE/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$ n",
+                "($ n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorrese peseta",

--- a/locale-tests/locales/nl-BE/numbers.js
+++ b/locale-tests/locales/nl-BE/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$ n",
+                "($ n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/nl-BQ/all.js
+++ b/locale-tests/locales/nl-BQ/all.js
@@ -53,6 +53,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$ n",
+                "($ n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorrese peseta",

--- a/locale-tests/locales/nl-BQ/numbers.js
+++ b/locale-tests/locales/nl-BQ/numbers.js
@@ -55,6 +55,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$ n",
+                "($ n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/nl-CW/all.js
+++ b/locale-tests/locales/nl-CW/all.js
@@ -53,6 +53,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$ n",
+                "($ n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorrese peseta",

--- a/locale-tests/locales/nl-CW/numbers.js
+++ b/locale-tests/locales/nl-CW/numbers.js
@@ -55,6 +55,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$ n",
+                "($ n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/nl-SR/all.js
+++ b/locale-tests/locales/nl-SR/all.js
@@ -53,6 +53,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$ n",
+                "($ n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorrese peseta",

--- a/locale-tests/locales/nl-SR/numbers.js
+++ b/locale-tests/locales/nl-SR/numbers.js
@@ -55,6 +55,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$ n",
+                "($ n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/nl-SX/all.js
+++ b/locale-tests/locales/nl-SX/all.js
@@ -53,6 +53,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$ n",
+                "($ n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorrese peseta",

--- a/locale-tests/locales/nl-SX/numbers.js
+++ b/locale-tests/locales/nl-SX/numbers.js
@@ -55,6 +55,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$ n",
+                "($ n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/nl/all.js
+++ b/locale-tests/locales/nl/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$ n",
+                "($ n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorrese peseta",

--- a/locale-tests/locales/nl/numbers.js
+++ b/locale-tests/locales/nl/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$ n",
+                "($ n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/pa-Guru/all.js
+++ b/locale-tests/locales/pa-Guru/all.js
@@ -55,6 +55,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$ n"
+            ],
+            groupSize: [
+                3,
+                2
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ADP",

--- a/locale-tests/locales/pa-Guru/numbers.js
+++ b/locale-tests/locales/pa-Guru/numbers.js
@@ -57,6 +57,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$ n"
+            ],
+            groupSize: [
+                3,
+                2
+            ]
         }
     }
 };

--- a/locale-tests/locales/pa/all.js
+++ b/locale-tests/locales/pa/all.js
@@ -54,6 +54,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$ n"
+            ],
+            groupSize: [
+                3,
+                2
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ADP",

--- a/locale-tests/locales/pa/numbers.js
+++ b/locale-tests/locales/pa/numbers.js
@@ -56,6 +56,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$ n"
+            ],
+            groupSize: [
+                3,
+                2
+            ]
         }
     }
 };

--- a/locale-tests/locales/pl/all.js
+++ b/locale-tests/locales/pl/all.js
@@ -53,6 +53,15 @@ const data = {
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "peseta andorska",

--- a/locale-tests/locales/pl/numbers.js
+++ b/locale-tests/locales/pl/numbers.js
@@ -55,6 +55,15 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/pt-AO/all.js
+++ b/locale-tests/locales/pt-AO/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Peseta de Andorra",

--- a/locale-tests/locales/pt-AO/numbers.js
+++ b/locale-tests/locales/pt-AO/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/pt-CH/all.js
+++ b/locale-tests/locales/pt-CH/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Peseta de Andorra",

--- a/locale-tests/locales/pt-CH/numbers.js
+++ b/locale-tests/locales/pt-CH/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/pt-CV/all.js
+++ b/locale-tests/locales/pt-CV/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Peseta de Andorra",

--- a/locale-tests/locales/pt-CV/numbers.js
+++ b/locale-tests/locales/pt-CV/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/pt-GQ/all.js
+++ b/locale-tests/locales/pt-GQ/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Peseta de Andorra",

--- a/locale-tests/locales/pt-GQ/numbers.js
+++ b/locale-tests/locales/pt-GQ/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/pt-GW/all.js
+++ b/locale-tests/locales/pt-GW/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Peseta de Andorra",

--- a/locale-tests/locales/pt-GW/numbers.js
+++ b/locale-tests/locales/pt-GW/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/pt-LU/all.js
+++ b/locale-tests/locales/pt-LU/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Peseta de Andorra",

--- a/locale-tests/locales/pt-LU/numbers.js
+++ b/locale-tests/locales/pt-LU/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/pt-MO/all.js
+++ b/locale-tests/locales/pt-MO/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Peseta de Andorra",

--- a/locale-tests/locales/pt-MO/numbers.js
+++ b/locale-tests/locales/pt-MO/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/pt-MZ/all.js
+++ b/locale-tests/locales/pt-MZ/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Peseta de Andorra",

--- a/locale-tests/locales/pt-MZ/numbers.js
+++ b/locale-tests/locales/pt-MZ/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/pt-PT/all.js
+++ b/locale-tests/locales/pt-PT/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Peseta de Andorra",

--- a/locale-tests/locales/pt-PT/numbers.js
+++ b/locale-tests/locales/pt-PT/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/pt-ST/all.js
+++ b/locale-tests/locales/pt-ST/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Peseta de Andorra",

--- a/locale-tests/locales/pt-ST/numbers.js
+++ b/locale-tests/locales/pt-ST/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/pt-TL/all.js
+++ b/locale-tests/locales/pt-TL/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Peseta de Andorra",

--- a/locale-tests/locales/pt-TL/numbers.js
+++ b/locale-tests/locales/pt-TL/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/pt/all.js
+++ b/locale-tests/locales/pt/all.js
@@ -51,6 +51,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Peseta de Andorra",

--- a/locale-tests/locales/pt/numbers.js
+++ b/locale-tests/locales/pt/numbers.js
@@ -53,6 +53,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ro-MD/all.js
+++ b/locale-tests/locales/ro-MD/all.js
@@ -53,6 +53,15 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-other": "n de $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "pesetă andorrană",

--- a/locale-tests/locales/ro-MD/numbers.js
+++ b/locale-tests/locales/ro-MD/numbers.js
@@ -55,6 +55,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-few": "n $",
             "unitPattern-count-other": "n de $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ro/all.js
+++ b/locale-tests/locales/ro/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-other": "n de $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "pesetă andorrană",

--- a/locale-tests/locales/ro/numbers.js
+++ b/locale-tests/locales/ro/numbers.js
@@ -54,6 +54,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-few": "n $",
             "unitPattern-count-other": "n de $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ru-BY/all.js
+++ b/locale-tests/locales/ru-BY/all.js
@@ -54,6 +54,14 @@ const data = {
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Андоррская песета",

--- a/locale-tests/locales/ru-BY/numbers.js
+++ b/locale-tests/locales/ru-BY/numbers.js
@@ -56,6 +56,14 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ru-KG/all.js
+++ b/locale-tests/locales/ru-KG/all.js
@@ -54,6 +54,14 @@ const data = {
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Андоррская песета",

--- a/locale-tests/locales/ru-KG/numbers.js
+++ b/locale-tests/locales/ru-KG/numbers.js
@@ -56,6 +56,14 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ru-KZ/all.js
+++ b/locale-tests/locales/ru-KZ/all.js
@@ -54,6 +54,14 @@ const data = {
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Андоррская песета",

--- a/locale-tests/locales/ru-KZ/numbers.js
+++ b/locale-tests/locales/ru-KZ/numbers.js
@@ -56,6 +56,14 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ru-MD/all.js
+++ b/locale-tests/locales/ru-MD/all.js
@@ -54,6 +54,14 @@ const data = {
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Андоррская песета",

--- a/locale-tests/locales/ru-MD/numbers.js
+++ b/locale-tests/locales/ru-MD/numbers.js
@@ -56,6 +56,14 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ru-UA/all.js
+++ b/locale-tests/locales/ru-UA/all.js
@@ -54,6 +54,14 @@ const data = {
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Андоррская песета",

--- a/locale-tests/locales/ru-UA/numbers.js
+++ b/locale-tests/locales/ru-UA/numbers.js
@@ -56,6 +56,14 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ru/all.js
+++ b/locale-tests/locales/ru/all.js
@@ -53,6 +53,14 @@ const data = {
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Андоррская песета",

--- a/locale-tests/locales/ru/numbers.js
+++ b/locale-tests/locales/ru/numbers.js
@@ -55,6 +55,14 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/si/all.js
+++ b/locale-tests/locales/si/all.js
@@ -51,6 +51,15 @@ const data = {
             "unitPattern-count-one": "$n",
             "unitPattern-count-other": "$n"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ADP",

--- a/locale-tests/locales/si/numbers.js
+++ b/locale-tests/locales/si/numbers.js
@@ -53,6 +53,15 @@ const data = {
             ],
             "unitPattern-count-one": "$n",
             "unitPattern-count-other": "$n"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/sk/all.js
+++ b/locale-tests/locales/sk/all.js
@@ -53,6 +53,15 @@ const data = {
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "andorská peseta",

--- a/locale-tests/locales/sk/numbers.js
+++ b/locale-tests/locales/sk/numbers.js
@@ -55,6 +55,15 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/sl/all.js
+++ b/locale-tests/locales/sl/all.js
@@ -53,6 +53,15 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "andorska peseta",

--- a/locale-tests/locales/sl/numbers.js
+++ b/locale-tests/locales/sl/numbers.js
@@ -55,6 +55,15 @@ const data = {
             "unitPattern-count-two": "n $",
             "unitPattern-count-few": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/sq-MK/all.js
+++ b/locale-tests/locales/sq-MK/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ADP",

--- a/locale-tests/locales/sq-MK/numbers.js
+++ b/locale-tests/locales/sq-MK/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/sq-XK/all.js
+++ b/locale-tests/locales/sq-XK/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ADP",

--- a/locale-tests/locales/sq-XK/numbers.js
+++ b/locale-tests/locales/sq-XK/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/sq/all.js
+++ b/locale-tests/locales/sq/all.js
@@ -51,6 +51,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ADP",

--- a/locale-tests/locales/sq/numbers.js
+++ b/locale-tests/locales/sq/numbers.js
@@ -53,6 +53,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/sr-Cyrl-BA/all.js
+++ b/locale-tests/locales/sr-Cyrl-BA/all.js
@@ -54,6 +54,15 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Андорска пезета",

--- a/locale-tests/locales/sr-Cyrl-BA/numbers.js
+++ b/locale-tests/locales/sr-Cyrl-BA/numbers.js
@@ -56,6 +56,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-few": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/sr-Cyrl-ME/all.js
+++ b/locale-tests/locales/sr-Cyrl-ME/all.js
@@ -54,6 +54,15 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Андорска пезета",

--- a/locale-tests/locales/sr-Cyrl-ME/numbers.js
+++ b/locale-tests/locales/sr-Cyrl-ME/numbers.js
@@ -56,6 +56,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-few": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/sr-Cyrl-XK/all.js
+++ b/locale-tests/locales/sr-Cyrl-XK/all.js
@@ -54,6 +54,15 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Андорска пезета",

--- a/locale-tests/locales/sr-Cyrl-XK/numbers.js
+++ b/locale-tests/locales/sr-Cyrl-XK/numbers.js
@@ -56,6 +56,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-few": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/sr-Cyrl/all.js
+++ b/locale-tests/locales/sr-Cyrl/all.js
@@ -53,6 +53,15 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Андорска пезета",

--- a/locale-tests/locales/sr-Cyrl/numbers.js
+++ b/locale-tests/locales/sr-Cyrl/numbers.js
@@ -55,6 +55,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-few": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/sr-Latn-BA/all.js
+++ b/locale-tests/locales/sr-Latn-BA/all.js
@@ -54,6 +54,15 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorska pezeta",

--- a/locale-tests/locales/sr-Latn-BA/numbers.js
+++ b/locale-tests/locales/sr-Latn-BA/numbers.js
@@ -56,6 +56,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-few": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/sr-Latn-ME/all.js
+++ b/locale-tests/locales/sr-Latn-ME/all.js
@@ -54,6 +54,15 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorska pezeta",

--- a/locale-tests/locales/sr-Latn-ME/numbers.js
+++ b/locale-tests/locales/sr-Latn-ME/numbers.js
@@ -56,6 +56,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-few": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/sr-Latn-XK/all.js
+++ b/locale-tests/locales/sr-Latn-XK/all.js
@@ -54,6 +54,15 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorska pezeta",

--- a/locale-tests/locales/sr-Latn-XK/numbers.js
+++ b/locale-tests/locales/sr-Latn-XK/numbers.js
@@ -56,6 +56,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-few": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/sr-Latn/all.js
+++ b/locale-tests/locales/sr-Latn/all.js
@@ -53,6 +53,15 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorska pezeta",

--- a/locale-tests/locales/sr-Latn/numbers.js
+++ b/locale-tests/locales/sr-Latn/numbers.js
@@ -55,6 +55,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-few": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/sr/all.js
+++ b/locale-tests/locales/sr/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Андорска пезета",

--- a/locale-tests/locales/sr/numbers.js
+++ b/locale-tests/locales/sr/numbers.js
@@ -54,6 +54,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-few": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $",
+                "(n $)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/sv-AX/all.js
+++ b/locale-tests/locales/sv-AX/all.js
@@ -53,6 +53,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "andorransk peseta",

--- a/locale-tests/locales/sv-AX/numbers.js
+++ b/locale-tests/locales/sv-AX/numbers.js
@@ -55,6 +55,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/sv-FI/all.js
+++ b/locale-tests/locales/sv-FI/all.js
@@ -53,6 +53,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "andorransk peseta",

--- a/locale-tests/locales/sv-FI/numbers.js
+++ b/locale-tests/locales/sv-FI/numbers.js
@@ -55,6 +55,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/sv/all.js
+++ b/locale-tests/locales/sv/all.js
@@ -52,6 +52,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "andorransk peseta",

--- a/locale-tests/locales/sv/numbers.js
+++ b/locale-tests/locales/sv/numbers.js
@@ -54,6 +54,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/sw-CD/all.js
+++ b/locale-tests/locales/sw-CD/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "$ n",
             "unitPattern-count-other": "$ n"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ADP",

--- a/locale-tests/locales/sw-CD/numbers.js
+++ b/locale-tests/locales/sw-CD/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "$ n",
             "unitPattern-count-other": "$ n"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/sw-KE/all.js
+++ b/locale-tests/locales/sw-KE/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "$ n",
             "unitPattern-count-other": "$ n"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ADP",

--- a/locale-tests/locales/sw-KE/numbers.js
+++ b/locale-tests/locales/sw-KE/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "$ n",
             "unitPattern-count-other": "$ n"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/sw-UG/all.js
+++ b/locale-tests/locales/sw-UG/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "$ n",
             "unitPattern-count-other": "$ n"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ADP",

--- a/locale-tests/locales/sw-UG/numbers.js
+++ b/locale-tests/locales/sw-UG/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "$ n",
             "unitPattern-count-other": "$ n"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/sw/all.js
+++ b/locale-tests/locales/sw/all.js
@@ -51,6 +51,15 @@ const data = {
             "unitPattern-count-one": "$ n",
             "unitPattern-count-other": "$ n"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ADP",

--- a/locale-tests/locales/sw/numbers.js
+++ b/locale-tests/locales/sw/numbers.js
@@ -53,6 +53,15 @@ const data = {
             ],
             "unitPattern-count-one": "$ n",
             "unitPattern-count-other": "$ n"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ta-LK/all.js
+++ b/locale-tests/locales/ta-LK/all.js
@@ -55,6 +55,16 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3,
+                2
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ADP",

--- a/locale-tests/locales/ta-LK/numbers.js
+++ b/locale-tests/locales/ta-LK/numbers.js
@@ -57,6 +57,16 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3,
+                2
+            ]
         }
     }
 };

--- a/locale-tests/locales/ta-MY/all.js
+++ b/locale-tests/locales/ta-MY/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ADP",

--- a/locale-tests/locales/ta-MY/numbers.js
+++ b/locale-tests/locales/ta-MY/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ta-SG/all.js
+++ b/locale-tests/locales/ta-SG/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ADP",

--- a/locale-tests/locales/ta-SG/numbers.js
+++ b/locale-tests/locales/ta-SG/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ta/all.js
+++ b/locale-tests/locales/ta/all.js
@@ -54,6 +54,16 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3,
+                2
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ADP",

--- a/locale-tests/locales/ta/numbers.js
+++ b/locale-tests/locales/ta/numbers.js
@@ -56,6 +56,16 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3,
+                2
+            ]
         }
     }
 };

--- a/locale-tests/locales/te/all.js
+++ b/locale-tests/locales/te/all.js
@@ -53,6 +53,16 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3,
+                2
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ADP",

--- a/locale-tests/locales/te/numbers.js
+++ b/locale-tests/locales/te/numbers.js
@@ -55,6 +55,16 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3,
+                2
+            ]
         }
     }
 };

--- a/locale-tests/locales/th/all.js
+++ b/locale-tests/locales/th/all.js
@@ -50,6 +50,15 @@ const data = {
             ],
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "เปเซตาอันดอร์รา",

--- a/locale-tests/locales/th/numbers.js
+++ b/locale-tests/locales/th/numbers.js
@@ -52,6 +52,15 @@ const data = {
                 3
             ],
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/to/all.js
+++ b/locale-tests/locales/to/all.js
@@ -50,6 +50,14 @@ const data = {
             ],
             "unitPattern-count-other": "$ n"
         },
+        accounting: {
+            patterns: [
+                "$ n"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ADP",

--- a/locale-tests/locales/to/numbers.js
+++ b/locale-tests/locales/to/numbers.js
@@ -52,6 +52,14 @@ const data = {
                 3
             ],
             "unitPattern-count-other": "$ n"
+        },
+        accounting: {
+            patterns: [
+                "$ n"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/tr-CY/all.js
+++ b/locale-tests/locales/tr-CY/all.js
@@ -52,6 +52,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorra Pezetası",

--- a/locale-tests/locales/tr-CY/numbers.js
+++ b/locale-tests/locales/tr-CY/numbers.js
@@ -54,6 +54,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/tr/all.js
+++ b/locale-tests/locales/tr/all.js
@@ -51,6 +51,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Andorra Pezetası",

--- a/locale-tests/locales/tr/numbers.js
+++ b/locale-tests/locales/tr/numbers.js
@@ -53,6 +53,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/uk/all.js
+++ b/locale-tests/locales/uk/all.js
@@ -53,6 +53,15 @@ const data = {
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n$",
+                "(n$)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "андоррська песета",

--- a/locale-tests/locales/uk/numbers.js
+++ b/locale-tests/locales/uk/numbers.js
@@ -55,6 +55,15 @@ const data = {
             "unitPattern-count-few": "n $",
             "unitPattern-count-many": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n$",
+                "(n$)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ur-IN/all.js
+++ b/locale-tests/locales/ur-IN/all.js
@@ -53,6 +53,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$ n"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ADP",

--- a/locale-tests/locales/ur-IN/numbers.js
+++ b/locale-tests/locales/ur-IN/numbers.js
@@ -55,6 +55,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$ n"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/ur/all.js
+++ b/locale-tests/locales/ur/all.js
@@ -52,6 +52,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$ n"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ADP",

--- a/locale-tests/locales/ur/numbers.js
+++ b/locale-tests/locales/ur/numbers.js
@@ -54,6 +54,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$ n"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/uz-Latn/all.js
+++ b/locale-tests/locales/uz-Latn/all.js
@@ -52,6 +52,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ADP",

--- a/locale-tests/locales/uz-Latn/numbers.js
+++ b/locale-tests/locales/uz-Latn/numbers.js
@@ -54,6 +54,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/uz/all.js
+++ b/locale-tests/locales/uz/all.js
@@ -51,6 +51,14 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ADP",

--- a/locale-tests/locales/uz/numbers.js
+++ b/locale-tests/locales/uz/numbers.js
@@ -53,6 +53,14 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/vi/all.js
+++ b/locale-tests/locales/vi/all.js
@@ -50,6 +50,14 @@ const data = {
             ],
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "Đồng Peseta của Andora",

--- a/locale-tests/locales/vi/numbers.js
+++ b/locale-tests/locales/vi/numbers.js
@@ -52,6 +52,14 @@ const data = {
                 3
             ],
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "n $"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/yue/all.js
+++ b/locale-tests/locales/yue/all.js
@@ -50,6 +50,15 @@ const data = {
             ],
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "安道爾陪士特",

--- a/locale-tests/locales/yue/numbers.js
+++ b/locale-tests/locales/yue/numbers.js
@@ -52,6 +52,15 @@ const data = {
                 3
             ],
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/zh-Hans-HK/all.js
+++ b/locale-tests/locales/zh-Hans-HK/all.js
@@ -52,6 +52,15 @@ const data = {
             ],
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "安道尔比塞塔",

--- a/locale-tests/locales/zh-Hans-HK/numbers.js
+++ b/locale-tests/locales/zh-Hans-HK/numbers.js
@@ -54,6 +54,15 @@ const data = {
                 3
             ],
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/zh-Hans-MO/all.js
+++ b/locale-tests/locales/zh-Hans-MO/all.js
@@ -52,6 +52,15 @@ const data = {
             ],
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "安道尔比塞塔",

--- a/locale-tests/locales/zh-Hans-MO/numbers.js
+++ b/locale-tests/locales/zh-Hans-MO/numbers.js
@@ -54,6 +54,15 @@ const data = {
                 3
             ],
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/zh-Hans-SG/all.js
+++ b/locale-tests/locales/zh-Hans-SG/all.js
@@ -52,6 +52,15 @@ const data = {
             ],
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "安道尔比塞塔",

--- a/locale-tests/locales/zh-Hans-SG/numbers.js
+++ b/locale-tests/locales/zh-Hans-SG/numbers.js
@@ -54,6 +54,15 @@ const data = {
                 3
             ],
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/zh-Hans/all.js
+++ b/locale-tests/locales/zh-Hans/all.js
@@ -51,6 +51,15 @@ const data = {
             ],
             "unitPattern-count-other": "n$"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "安道尔比塞塔",

--- a/locale-tests/locales/zh-Hans/numbers.js
+++ b/locale-tests/locales/zh-Hans/numbers.js
@@ -53,6 +53,15 @@ const data = {
                 3
             ],
             "unitPattern-count-other": "n$"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/zh-Hant-HK/all.js
+++ b/locale-tests/locales/zh-Hant-HK/all.js
@@ -52,6 +52,15 @@ const data = {
             ],
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "安道爾陪士特",

--- a/locale-tests/locales/zh-Hant-HK/numbers.js
+++ b/locale-tests/locales/zh-Hant-HK/numbers.js
@@ -54,6 +54,15 @@ const data = {
                 3
             ],
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/zh-Hant-MO/all.js
+++ b/locale-tests/locales/zh-Hant-MO/all.js
@@ -52,6 +52,15 @@ const data = {
             ],
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "安道爾陪士特",

--- a/locale-tests/locales/zh-Hant-MO/numbers.js
+++ b/locale-tests/locales/zh-Hant-MO/numbers.js
@@ -54,6 +54,15 @@ const data = {
                 3
             ],
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/zh-Hant/all.js
+++ b/locale-tests/locales/zh-Hant/all.js
@@ -51,6 +51,15 @@ const data = {
             ],
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "安道爾陪士特",

--- a/locale-tests/locales/zh-Hant/numbers.js
+++ b/locale-tests/locales/zh-Hant/numbers.js
@@ -54,6 +54,15 @@ const data = {
                 3
             ],
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/zh/all.js
+++ b/locale-tests/locales/zh/all.js
@@ -50,6 +50,15 @@ const data = {
             ],
             "unitPattern-count-other": "n$"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "安道尔比塞塔",

--- a/locale-tests/locales/zh/numbers.js
+++ b/locale-tests/locales/zh/numbers.js
@@ -52,6 +52,15 @@ const data = {
                 3
             ],
             "unitPattern-count-other": "n$"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/locale-tests/locales/zu/all.js
+++ b/locale-tests/locales/zu/all.js
@@ -51,6 +51,15 @@ const data = {
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
         },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
+        },
         currencies: {
             ADP: {
                 displayName: "ADP",

--- a/locale-tests/locales/zu/numbers.js
+++ b/locale-tests/locales/zu/numbers.js
@@ -53,6 +53,15 @@ const data = {
             ],
             "unitPattern-count-one": "n $",
             "unitPattern-count-other": "n $"
+        },
+        accounting: {
+            patterns: [
+                "$n",
+                "($n)"
+            ],
+            groupSize: [
+                3
+            ]
         }
     }
 };

--- a/src/cldr/date-field-name.js
+++ b/src/cldr/date-field-name.js
@@ -1,7 +1,8 @@
 import { localeInfo } from './info';
 import { errors } from '../errors';
+import { DEFAULT_LOCALE } from '../common/constants';
 
-export default function dateFieldName(options, locale = "en") {
+export default function dateFieldName(options, locale = DEFAULT_LOCALE) {
     const info = localeInfo(locale);
     const dateFields = info.calendar.dateFields;
     if (!dateFields) {

--- a/src/cldr/date-format-names.js
+++ b/src/cldr/date-format-names.js
@@ -1,4 +1,5 @@
 import { getLocaleInfo } from './info';
+import { EMPTY } from '../common/constants';
 
 function lowerArray(arr) {
     const result = [];
@@ -25,7 +26,7 @@ export default function dateFormatNames(locale, options) {
     const { type, nameType, standAlone, lower } = options;
     const info = getLocaleInfo(locale);
     const formatType = standAlone ? "stand-alone" : "format";
-    const lowerNameType = (lower ? "lower-" : "") + nameType;
+    const lowerNameType = (lower ? "lower-" : EMPTY) + nameType;
     const formatNames = info.calendar[type][formatType];
     let result = formatNames[lowerNameType];
     if (!result && lower) {

--- a/src/cldr/default-data.js
+++ b/src/cldr/default-data.js
@@ -78,7 +78,16 @@ const defaultData = {
                     "symbol-alt-narrow": "$"
                 }
             },
-            localeCurrency: "USD"
+            localeCurrency: "USD",
+            accounting: {
+                patterns: [
+                    "$n",
+                    "($n)"
+                ],
+                groupSize: [
+                    3
+                ]
+            }
         },
         calendar: {
             gmtFormat: "GMT{0}",

--- a/src/cldr/info.js
+++ b/src/cldr/info.js
@@ -1,4 +1,5 @@
 import defaultData from './default-data';
+import isString from '../common/is-string';
 import { errors } from '../errors';
 
 function availableLocaleInfo(fullName, suffixes) {
@@ -29,7 +30,7 @@ export const cldr = defaultData;
 
 export function getLocaleInfo(locale) {
     let info;
-    if (typeof locale === "string") {
+    if (isString(locale)) {
         info = localeInfo(locale);
     } else {
         info = locale;

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -1,0 +1,19 @@
+export const DECIMAL = "decimal";
+export const CURRENCY = "currency";
+export const ACCOUNTING = "accounting";
+export const PERCENT = "percent";
+export const SCIENTIFIC = "scientific";
+
+//rename to placeholder
+export const CURRENCY_SYMBOL = "$";
+export const PERCENT_SYMBOL = "%";
+export const NUMBER_SYMBOL = "n";
+
+export const LIST_SEPARATOR = ";";
+export const GROUP_SEPARATOR = ",";
+
+export const POINT = ".";
+export const EMPTY = "";
+
+export const DEFAULT_LOCALE = "en";
+

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -4,10 +4,9 @@ export const ACCOUNTING = "accounting";
 export const PERCENT = "percent";
 export const SCIENTIFIC = "scientific";
 
-//rename to placeholder
-export const CURRENCY_SYMBOL = "$";
-export const PERCENT_SYMBOL = "%";
-export const NUMBER_SYMBOL = "n";
+export const CURRENCY_PLACEHOLDER = "$";
+export const PERCENT_PLACEHOLDER = "%";
+export const NUMBER_PLACEHOLDER = "n";
 
 export const LIST_SEPARATOR = ";";
 export const GROUP_SEPARATOR = ",";

--- a/src/common/is-number.js
+++ b/src/common/is-number.js
@@ -1,0 +1,3 @@
+export default function isNumber(value) {
+    return typeof value === "number";
+}

--- a/src/common/is-string.js
+++ b/src/common/is-string.js
@@ -1,0 +1,3 @@
+export default function isString(value) {
+    return typeof value === "string";
+}

--- a/src/dates/date-pattern.js
+++ b/src/dates/date-pattern.js
@@ -1,4 +1,5 @@
 import formatString from '../common/format-string';
+import isString from '../common/is-string';
 import { EMPTY } from '../common/constants';
 
 const REMOVAL_PENALTY = 120;
@@ -192,7 +193,7 @@ function skeletonFromOptions(options) {
 export default function datePattern(format, info) {
     const calendar = info.calendar;
     let result;
-    if (typeof format === "string") {
+    if (isString(format)) {
         if (calendar.patterns[format]) {
             result = calendar.patterns[format];
         } else {

--- a/src/dates/date-pattern.js
+++ b/src/dates/date-pattern.js
@@ -1,4 +1,5 @@
 import formatString from '../common/format-string';
+import { EMPTY } from '../common/constants';
 
 const REMOVAL_PENALTY = 120;
 const ADDITION_PENALTY = 20;
@@ -103,7 +104,7 @@ function findBestMatch(specifiers, availableFormats) {
             if (!match) {
                 score -= REMOVAL_PENALTY;
             } else {
-                currentFormat = currentFormat.replace(match, "");
+                currentFormat = currentFormat.replace(match, EMPTY);
                 if (match.length !== specifier.length) {
                     let delta = Math.max(Math.min(LENGHT_DELTA[match.length] - LENGHT_DELTA[specifier.length], 2), -2);
                     score -= PENALTIES[delta];
@@ -185,7 +186,7 @@ function skeletonFromOptions(options) {
         }
     }
 
-    return result.join("");
+    return result.join(EMPTY);
 }
 
 export default function datePattern(format, info) {

--- a/src/dates/format-date.js
+++ b/src/dates/format-date.js
@@ -1,4 +1,5 @@
 import { localeInfo, firstDay } from '../cldr';
+import { DEFAULT_LOCALE, EMPTY } from '../common/constants';
 import formatString from '../common/format-string';
 import datePattern from './date-pattern';
 import formatNames from './format-names';
@@ -46,7 +47,7 @@ function formatTimeZone(date, info, options) {
     const minutes = hoursMinutes[1] || 0;
     let result = sign + (shortHours ? hoursMinutes[0] : pad(hoursMinutes[0], 2));
     if (minutes || !optionalMinutes) {
-        result += (separator ? ":" : "") + pad(minutes, 2);
+        result += (separator ? ":" : EMPTY) + pad(minutes, 2);
     }
 
     if (localizedName) {
@@ -116,7 +117,7 @@ formatters.S = function(date, formatLength) {
     if (milliseconds !== 0) {
         result = String(date.getMilliseconds() / 1000).split(".")[1].substr(0, formatLength);
     } else {
-        result = pad("", formatLength);
+        result = pad(EMPTY, formatLength);
     }
     return result;
 };
@@ -174,10 +175,10 @@ formatters.q = function(date, formatLength, info) {
 
 formatters.Q = formatQuarter;
 
-export default function formatDate(date, format, locale = "en") {
+export default function formatDate(date, format, locale = DEFAULT_LOCALE) {
     if (!isDate(date)) {
         if (date === undefined || date === null) {
-            return '';
+            return EMPTY;
         }
         return date;
     }

--- a/src/dates/parse-date.js
+++ b/src/dates/parse-date.js
@@ -1,5 +1,6 @@
 import { adjustDST, convertTimeZone } from './time-utils';
 import { localeInfo } from '../cldr';
+import { DEFAULT_LOCALE, EMPTY } from '../common/constants';
 import { errors } from '../errors';
 import formatNames from './format-names';
 import datePattern from './date-pattern';
@@ -116,7 +117,7 @@ function calendarGmtFormats(calendar) {
         throw errors.NoGMTInfo.error();
     }
 
-    return [ gmtFormat.replace(PLACEHOLDER, "").toLowerCase(), gmtZeroFormat.replace(PLACEHOLDER, "").toLowerCase() ];
+    return [ gmtFormat.replace(PLACEHOLDER, EMPTY).toLowerCase(), gmtZeroFormat.replace(PLACEHOLDER, EMPTY).toLowerCase() ];
 }
 
 function parseTimeZoneOffset(state, info, options) {
@@ -431,7 +432,7 @@ function createDate(state) {
 }
 
 function parseExact(value, format, info) {
-    let pattern = datePattern(format, info).split("");
+    let pattern = datePattern(format, info).split(EMPTY);
 
     const state = {
         format: pattern,
@@ -521,7 +522,7 @@ function defaultFormats(calendar) {
     return formats.concat(standardDateFormats);
 }
 
-export default function parseDate(value, formats, locale = "en") {
+export default function parseDate(value, formats, locale = DEFAULT_LOCALE) {
     if (!value) {
         return null;
     }

--- a/src/dates/split-date-format.js
+++ b/src/dates/split-date-format.js
@@ -1,3 +1,4 @@
+import { DEFAULT_LOCALE } from '../common/constants';
 import datePattern from './date-pattern';
 import dateNameType from './date-name-type';
 import { dateFormatRegExp, DATE_FIELD_MAP } from './constants';
@@ -56,7 +57,7 @@ function isHour12(pattern) {
     return pattern === 'h';
 }
 
-export default function splitDateFormat(format, locale = 'en') {
+export default function splitDateFormat(format, locale = DEFAULT_LOCALE) {
     const info = localeInfo(locale);
     const pattern = datePattern(format, info);
     const parts = [];

--- a/src/dates/split-date-format.js
+++ b/src/dates/split-date-format.js
@@ -1,4 +1,5 @@
 import { DEFAULT_LOCALE } from '../common/constants';
+import isNumber from '../common/is-number';
 import datePattern from './date-pattern';
 import dateNameType from './date-name-type';
 import { dateFormatRegExp, DATE_FIELD_MAP } from './constants';
@@ -39,7 +40,6 @@ const NAME_TYPES = {
 };
 
 const LITERAL = 'literal';
-const NUMBER = 'number';
 
 function addLiteral(parts, value) {
     const lastPart = parts[parts.length - 1];
@@ -88,7 +88,7 @@ export default function splitDateFormat(format, locale = DEFAULT_LOCALE) {
             const names = NAME_TYPES[type];
 
             if (names) {
-                const minLength = typeof names.minLength === NUMBER ? names.minLength : names.minLength[specifier];
+                const minLength = isNumber(names.minLength) ? names.minLength : names.minLength[specifier];
                 const patternLength = value.length;
 
                 if (patternLength >= minLength) {

--- a/src/format.js
+++ b/src/format.js
@@ -1,5 +1,6 @@
 import { formatDate } from './dates';
 import { formatNumber } from './numbers';
+import { EMPTY } from './common/constants';
 import isDate from './common/is-date';
 
 const formatRegExp = /\{(\d+)(:[^\}]+)?\}/g;
@@ -13,13 +14,13 @@ export function toString(value, format, locale) {
         }
     }
 
-    return value !== undefined && value !== null ? value : "";
+    return value !== undefined && value !== null ? value : EMPTY;
 }
 
 export function format(format, values, locale) {
     return format.replace(formatRegExp, function(match, index, placeholderFormat) {
         let value = values[parseInt(index, 10)];
 
-        return toString(value, placeholderFormat ? placeholderFormat.substring(1) : "", locale);
+        return toString(value, placeholderFormat ? placeholderFormat.substring(1) : EMPTY, locale);
     });
 }

--- a/src/format.js
+++ b/src/format.js
@@ -2,6 +2,7 @@ import { formatDate } from './dates';
 import { formatNumber } from './numbers';
 import { EMPTY } from './common/constants';
 import isDate from './common/is-date';
+import isNumber from './common/is-number';
 
 const formatRegExp = /\{(\d+)(:[^\}]+)?\}/g;
 
@@ -9,7 +10,7 @@ export function toString(value, format, locale) {
     if (format) {
         if (isDate(value)) {
             return formatDate(value, format, locale);
-        } else if (typeof value === "number") {
+        } else if (isNumber(value)) {
             return formatNumber(value, format, locale);
         }
     }

--- a/src/numbers.d.ts
+++ b/src/numbers.d.ts
@@ -6,7 +6,7 @@ export interface NumberFormatOptions {
     /**
      * Specifies the format style.
      */
-    style?: 'decimal' | 'currency' | 'percent' | 'scientific';
+    style?: 'decimal' | 'currency' | 'percent' | 'scientific' | 'accounting';
 
     /**
      * Defines the currency code of the currency that is used in the formatting.

--- a/src/numbers/custom-number-format.js
+++ b/src/numbers/custom-number-format.js
@@ -1,17 +1,12 @@
+import { CURRENCY, PERCENT, LIST_SEPARATOR, GROUP_SEPARATOR, CURRENCY_PLACEHOLDER, PERCENT_PLACEHOLDER, POINT, EMPTY } from '../common/constants';
 import formatCurrencySymbol from './format-currency-symbol';
 import groupInteger from './group-integer';
 import round from '../common/round';
 
-const CURRENCY_SYMBOL = "$";
-const PERCENT_SYMBOL = "%";
 const PLACEHOLDER = "__??__";
-const CURRENCY = "currency";
-const PERCENT = "percent";
-const POINT = ".";
-const COMMA = ",";
+
 const SHARP = "#";
 const ZERO = "0";
-const EMPTY = "";
 
 const literalRegExp = /(\\.)|(['][^']*[']?)|(["][^"]*["]?)/g;
 const trailingZerosRegExp = /(\.(?:[0-9]*[1-9])?)0+$/g;
@@ -23,8 +18,8 @@ function setFormatLiterals(formatOptions) {
     if (format.indexOf("'") > -1 || format.indexOf("\"") > -1 || format.indexOf("\\") > -1) {
         const literals = formatOptions.literals = [];
         formatOptions.format = format.replace(literalRegExp, function(match) {
-            const quoteChar = match.charAt(0).replace("\\", "");
-            const literal = match.slice(1).replace(quoteChar, "");
+            const quoteChar = match.charAt(0).replace("\\", EMPTY);
+            const literal = match.slice(1).replace(quoteChar, EMPTY);
 
             literals.push(literal);
 
@@ -42,7 +37,7 @@ function trimTrailingZeros(value, lastZero) {
         trimRegex = new RegExp(`(\\.[0-9]{${ lastZero }}[1-9]*)0+$`, 'g');
     }
 
-    return value.replace(trimRegex, '$1').replace(trailingPointRegExp, '');
+    return value.replace(trimRegex, '$1').replace(trailingPointRegExp, EMPTY);
 }
 
 function roundNumber(formatOptions) {
@@ -106,7 +101,7 @@ function isConstantFormat(format) {
 
 function setValueSpecificFormat(formatOptions) {
     let { number, format } = formatOptions;
-    format = format.split(";");
+    format = format.split(LIST_SEPARATOR);
     if (formatOptions.negative && format[1]) {
         format = format[1];
         formatOptions.hasNegativeFormat = true;
@@ -127,20 +122,20 @@ function setStyleOptions(formatOptions, info) {
     const format = formatOptions.format;
 
     //multiply number if the format has percent
-    if (format.indexOf(PERCENT_SYMBOL) !== -1) {
+    if (format.indexOf(PERCENT_PLACEHOLDER) !== -1) {
         formatOptions.style = PERCENT;
         formatOptions.symbol = info.numbers.symbols.percentSign;
         formatOptions.number *= 100;
     }
 
-    if (format.indexOf(CURRENCY_SYMBOL) !== -1) {
+    if (format.indexOf(CURRENCY_PLACEHOLDER) !== -1) {
         formatOptions.style = CURRENCY;
         formatOptions.symbol = formatCurrencySymbol(info);
     }
 }
 
 function setGroupOptions(formatOptions) {
-    formatOptions.hasGroup = formatOptions.format.indexOf(COMMA) > -1;
+    formatOptions.hasGroup = formatOptions.format.indexOf(GROUP_SEPARATOR) > -1;
     if (formatOptions.hasGroup) {
         formatOptions.format = formatOptions.format.replace(commaRegExp, EMPTY);
     }
@@ -185,7 +180,7 @@ function replaceStyleSymbols(number, style, symbol) {
         result = EMPTY;
         for (let idx = 0, length = number.length; idx < length; idx++) {
             let ch = number.charAt(idx);
-            result += (ch === CURRENCY_SYMBOL || ch === PERCENT_SYMBOL) ? symbol : ch;
+            result += (ch === CURRENCY_PLACEHOLDER || ch === PERCENT_PLACEHOLDER) ? symbol : ch;
         }
     }
     return result;

--- a/src/numbers/format-number.js
+++ b/src/numbers/format-number.js
@@ -1,29 +1,28 @@
 import { localeInfo } from '../cldr';
+import { CURRENCY, ACCOUNTING, DECIMAL, PERCENT, SCIENTIFIC, DEFAULT_LOCALE, NUMBER_PLACEHOLDER, EMPTY } from '../common/constants';
 import standardNumberFormat from './standard-number-format';
 import customNumberFormat from './custom-number-format';
 
-const standardFormatRegExp = /^(n|c|p|e)(\d*)$/i;
+const standardFormatRegExp = /^(n|c|p|e|a)(\d*)$/i;
 
 function standardFormatOptions(format) {
     const formatAndPrecision = standardFormatRegExp.exec(format);
 
     if (formatAndPrecision) {
         const options = {
-            style: "decimal"
+            style: DECIMAL
         };
 
         let style = formatAndPrecision[1].toLowerCase();
 
         if (style === "c") {
-            options.style = "currency";
-        }
-
-        if (style === "p") {
-            options.style = "percent";
-        }
-
-        if (style === "e") {
-            options.style = "scientific";
+            options.style = CURRENCY;
+        } else if (style === "a") {
+            options.style = ACCOUNTING;
+        } else if (style === "p") {
+            options.style = PERCENT;
+        } else if (style === "e") {
+            options.style = SCIENTIFIC;
         }
 
         if (formatAndPrecision[2]) {
@@ -45,9 +44,9 @@ function getFormatOptions(format) {
     return formatOptions;
 }
 
-export default function formatNumber(number, format = "n", locale = "en") {
+export default function formatNumber(number, format = NUMBER_PLACEHOLDER, locale = DEFAULT_LOCALE) {
     if (number === undefined || number === null) {
-        return "";
+        return EMPTY;
     }
 
     if (!isFinite(number)) {
@@ -59,7 +58,7 @@ export default function formatNumber(number, format = "n", locale = "en") {
 
     let result;
     if (formatOptions) {
-        const style = (formatOptions || {}).style || "decimal";
+        const style = (formatOptions || {}).style || DECIMAL;
         result = standardNumberFormat(number, Object.assign({}, info.numbers[style], formatOptions), info);
     } else {
         result = customNumberFormat(number, format, info);

--- a/src/numbers/format-number.js
+++ b/src/numbers/format-number.js
@@ -1,5 +1,6 @@
 import { localeInfo } from '../cldr';
 import { CURRENCY, ACCOUNTING, DECIMAL, PERCENT, SCIENTIFIC, DEFAULT_LOCALE, NUMBER_PLACEHOLDER, EMPTY } from '../common/constants';
+import isString from '../common/is-string';
 import standardNumberFormat from './standard-number-format';
 import customNumberFormat from './custom-number-format';
 
@@ -35,7 +36,7 @@ function standardFormatOptions(format) {
 
 function getFormatOptions(format) {
     let formatOptions;
-    if (typeof format === "string") {
+    if (isString(format)) {
         formatOptions = standardFormatOptions(format);
     } else {
         formatOptions = format;

--- a/src/numbers/is-currency-style.js
+++ b/src/numbers/is-currency-style.js
@@ -1,0 +1,5 @@
+import { CURRENCY, ACCOUNTING } from '../common/constants';
+
+export default function isCurrencyStyle(style) {
+    return style === CURRENCY || style === ACCOUNTING;
+}

--- a/src/numbers/parse-number.js
+++ b/src/numbers/parse-number.js
@@ -1,5 +1,6 @@
 import { localeInfo, localeCurrency, currencyDisplays } from '../cldr';
 import { PERCENT, NUMBER_PLACEHOLDER, CURRENCY_PLACEHOLDER, DEFAULT_LOCALE, EMPTY, POINT } from '../common/constants';
+import isNumber from '../common/is-number';
 import isCurrencyStyle from './is-currency-style';
 
 const exponentRegExp = /[eE][\-+]?[0-9]+/;
@@ -48,7 +49,7 @@ export default function parseNumber(value, locale = DEFAULT_LOCALE, format = {})
         return null;
     }
 
-    if (typeof value === "number") {
+    if (isNumber(value)) {
         return value;
     }
 

--- a/test/numbers.js
+++ b/test/numbers.js
@@ -25,7 +25,8 @@ function loadCustom(options) {
               "standard": options.pattern || "#,##0.###"
             },
             "currencyFormats-numberSystem-latn": {
-              "standard": options.currencyPattern || "¤#,##0.00"
+              "standard": options.currencyPattern || "¤#,##0.00",
+              "accounting": options.accountingPattern || "#,##0.00¤"
             },
             currencies: options.currencies
           }
@@ -320,6 +321,75 @@ describe('standard currency formatting', () => {
 
     it("should apply maximumFractionDigits", () => {
         expect(formatNumber(10.1235, { style: "currency", maximumFractionDigits: 3 })).toEqual("$10.124");
+    });
+
+});
+
+describe('standard accounting formatting', () => {
+
+    beforeAll(() => {
+        loadCustom({ currencies: { USD: { symbol: "$" }} });
+        cldr.custom.numbers.localeCurrency = "USD";
+    });
+
+    afterAll(() => {
+        delete cldr.custom;
+    });
+
+    it('should apply format', () => {
+        expect(formatNumber(10, 'a', 'custom')).toEqual("10.00$");
+    });
+
+    it('should apply format with precision', () => {
+        expect(formatNumber(10, 'a0')).toEqual("$10");
+    });
+
+    it('should apply format for negative numbers', () => {
+        expect(formatNumber(-10.3337, 'a3')).toEqual("($10.334)");
+    });
+
+    it("should apply group separators", () => {
+        expect(formatNumber(123456789, 'a')).toEqual("$123,456,789.00");
+    });
+
+    it("should not apply group separators to numbers with less digits", () => {
+        expect(formatNumber(123, "a")).toEqual("$123.00");
+    });
+
+    it("should apply format when passing language", () => {
+        expect(formatNumber(10, "a", "bg")).toEqual("10,00 лв.");
+    });
+
+    it("should apply format when passing language and territory", () => {
+        expect(formatNumber(10, "a", "bg-BG")).toEqual("10,00 лв.");
+    });
+
+    it("should apply format when passing object", () => {
+        expect(formatNumber(10, { style: "accounting" })).toEqual("$10.00");
+    });
+
+    it("should apply format for specific currency", () => {
+        expect(formatNumber(10, { style: "accounting", currency: "BGN" })).toEqual("BGN10.00");
+    });
+
+    it("should apply specific currency display", () => {
+        expect(formatNumber(10, { style: "accounting", currency: "BGN", currencyDisplay: "name" })).toEqual("10.00 Bulgarian leva");
+    });
+
+    it("should format negative currency with name", () => {
+        expect(formatNumber(-10, { style: "accounting", currency: "BGN", currencyDisplay: "name" })).toEqual("-10.00 Bulgarian leva");
+    });
+
+    it("should format currency equal to one with name", () => {
+        expect(formatNumber(1, { style: "accounting", currency: "BGN", currencyDisplay: "name" })).toEqual("1.00 Bulgarian lev");
+    });
+
+    it("should apply minimumFractionDigits", () => {
+        expect(formatNumber(10, { style: "accounting", minimumFractionDigits: 5 })).toEqual("$10.00000");
+    });
+
+    it("should apply maximumFractionDigits", () => {
+        expect(formatNumber(10.1235, { style: "accounting", maximumFractionDigits: 3 })).toEqual("$10.124");
     });
 
 });


### PR DESCRIPTION
Support for the other currency format available in the cldr data. 
Usage:

formatNumber(10, 'a');
formatNumber(10, 'a3');
formatNumber(10, { style: 'accounting' });