### PR TITLE
fix: link to license agreement

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -2,8 +2,6 @@ This project has been released under the [Apache License, version 2.0](http://ww
 
 *Copyright © 2019 Progress Software EAD*
 
-> Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0).
-> 
-> Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-> 
-> See the License for the specific language governing permissions and limitations under the License.
+> * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0).
+> * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+> * See the License for the specific language governing permissions and limitations under the License.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-This project has been released under the [Apache License, version 2.0](http://www.apache.org/licenses/LICENSE-2.0.html), the text of which is included below. This license applies ONLY to the source of this repository and does not extend to any other Kendo UI distribution or variant, or any other 3rd party libraries used in a repository. For licensing information about Kendo UI, see the [License Agreements page](https://www.kendoui.com/purchase/license-agreement.aspx) at [KendoUI.com](http://www.kendoui.com).
+This project has been released under the [Apache License, version 2.0](http://www.apache.org/licenses/LICENSE-2.0.html), the text of which is included below. This license applies ONLY to the source of this repository and does not extend to any other Kendo UI distribution or variant, or any other 3rd party libraries used in a repository. For licensing information about Kendo UI, see the [License Agreements page](https://www.telerik.com/purchase/license-agreements) at [telerik.com](https://www.telerik.com).
 
 *Copyright © 2019 Progress Software EAD*
 


### PR DESCRIPTION
Link pointed to the now unused kendoui.com domain.