### PR TITLE
feat: add millisecond support

### DIFF
--- a/src/cldr/default-data.js
+++ b/src/cldr/default-data.js
@@ -535,6 +535,11 @@ const defaultData = {
                     short: "sec.",
                     narrow: "sec."
                 },
+                millisecond: {
+                    wide: "millisecond",
+                    short: "ms",
+                    narrow: "ms"
+                },
                 zone: {
                     wide: "time zone"
                 }

--- a/src/dates/constants.js
+++ b/src/dates/constants.js
@@ -21,6 +21,7 @@ const DATE_FIELD_MAP = {
     'K': HOUR,
     'm': 'minute',
     's': 'second',
+    'S': 'millisecond',
     'a': 'dayperiod',
     'x': ZONE,
     'X': ZONE,

--- a/src/dates/format-date.js
+++ b/src/dates/format-date.js
@@ -123,7 +123,7 @@ formatters.S = function(date, formatLength) {
     const milliseconds = date.getMilliseconds();
     let result;
     if (milliseconds !== 0) {
-        result = String(date.getMilliseconds() / 1000).split(".")[1].substr(0, formatLength);
+        result = pad(String(milliseconds / 1000).split(".")[1].substr(0, formatLength), formatLength, true);
     } else {
         result = pad(EMPTY, formatLength);
     }

--- a/test/cldr.js
+++ b/test/cldr.js
@@ -569,6 +569,12 @@ describe('dateFieldName', () => {
         expect(dateFieldName({ type: 'second', nameType: 'short' })).toEqual("sec.");
     });
 
+    it('should return placeholder for millisecond type', () => {
+        expect(dateFieldName({ type: 'millisecond', nameType: 'wide' })).toEqual("millisecond");
+        expect(dateFieldName({ type: 'millisecond', nameType: 'narrow' })).toEqual("ms");
+        expect(dateFieldName({ type: 'millisecond', nameType: 'short' })).toEqual("ms");
+    });
+    
     it('should return placeholder for zone type', () => {
         expect(dateFieldName({ type: 'zone', nameType: 'wide' })).toEqual("time zone");
         expect(dateFieldName({ type: 'zone', nameType: 'narrow' })).toEqual("time zone");
@@ -576,9 +582,9 @@ describe('dateFieldName', () => {
     });
 
     it('should return undefined for missing fieldName type', () => {
-        expect(dateFieldName({ type: 'millisecond', nameType: 'wide' })).toEqual(undefined);
-        expect(dateFieldName({ type: 'millisecond', nameType: 'narrow' })).toEqual(undefined);
-        expect(dateFieldName({ type: 'millisecond', nameType: 'short' })).toEqual(undefined);
+        expect(dateFieldName({ type: 'turbosecond', nameType: 'wide' })).toEqual(undefined);
+        expect(dateFieldName({ type: 'turbosecond', nameType: 'narrow' })).toEqual(undefined);
+        expect(dateFieldName({ type: 'turbosecond', nameType: 'short' })).toEqual(undefined);
     });
 
     it('should return wide placeholder by default', () => {

--- a/test/dates.js
+++ b/test/dates.js
@@ -236,6 +236,10 @@ describe('date formatting', () => {
         expect(formatDate(date(2000, 1, 1, 1, 1, 1, 100), "hh:mm:S")).toEqual('01:01:1');
     });
 
+    it('supports SSS with round numbers', () => {
+        expect(formatDate(date(2000, 1, 1, 1, 1, 1, 100), "hh:mm:SSS")).toEqual('01:01:100');
+    });
+
     it('supports S less than 100', () => {
         expect(formatDate(date(2000, 1, 1, 1, 1, 1, 99), "hh:mm:S")).toEqual('01:01:0');
     });


### PR DESCRIPTION
This PR is related to and necessitated by [this issue]( https://github.com/telerik/kendo-angular-dateinputs/issues/358).
In short, we want to support displaying and editing milliseconds in our date inputs.

Relevant links:
Corresponding PR in dateinputs repo: https://github.com/telerik/kendo-angular-dateinputs/pull/371
Feature Request: https://feedback.telerik.com/kendo-angular-ui/1472147-add-millisecond-support-to-date-time-picker