### PR TITLE
test: ISO date string millisecond parsing

### DIFF
--- a/test/dates.js
+++ b/test/dates.js
@@ -927,6 +927,12 @@ describe('date parsing', () => {
         expect(parseDate("2000-10-10T14:30:0.0400000Z", "yyyy-MM-ddTHH:mm:ss.SSSSSSSX").getMilliseconds()).toEqual(40);
     });
 
+    it('parses first digit of ISO date string milliseconds as hundreds', () => {
+        expect(parseDate("2000-01-01T00:00:00.1Z").getMilliseconds()).toEqual(100);
+        expect(parseDate("2000-01-01T00:00:00.10Z").getMilliseconds()).toEqual(100);
+        expect(parseDate("2000-01-01T00:00:00.100Z").getMilliseconds()).toEqual(100);
+    });
+
     it("parses UTC milliseconds without specified format", () => {
         const utcDate = new Date(Date.UTC(2000, 9, 10, 14, 30, 0, 450));
         expect(parseDate("2000-10-10T14:30:0.45Z").getMilliseconds()).toEqual(utcDate.getMilliseconds());


### PR DESCRIPTION
I was about to change how the "S" parser works, so that it parses "1" as 1 millisecond and not 100.

Thanks to @tsvetomir I realised that unlike the "s" parser, "S" needs to regard 1-digit values as hundreds in order to handle ISO date strings correctly.

Adding this to avoid such mistakes.