### PR TITLE
Bump tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {},
   "devDependencies": {
     "@telerik/eslint-config": "^1.0.0",
-    "@progress/kendo-package-tasks": "cdn-bundle",
+    "@progress/kendo-package-tasks": "^4.0.34",
     "@telerik/semantic-prerelease": "^1.3.3",
     "cldr-data": "latest",
     "cz-conventional-changelog": "^1.1.5",


### PR DESCRIPTION
Replaces dist-tag with latest tasks version. See https://github.com/telerik/kendo-build-tasks/pull/327