### PR TITLE
Fix scope

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,21 @@
+module.exports = {
+    "env": {
+        "browser": true,
+        "es2021": true,
+    },
+    "extends": [
+        "eslint:recommended",
+        "plugin:@typescript-eslint/recommended"
+    ],
+    "parser": "@typescript-eslint/parser",
+    "parserOptions": {
+        "ecmaVersion": "latest",
+        "sourceType": "module"
+    },
+    "plugins": [
+        "@typescript-eslint"
+    ],
+    "rules": {
+        "@typescript-eslint/no-explicit-any": 0
+    }
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./node_modules/@telerik/eslint-config/index.js",
-  "rules": {
-    "max-params": [ 2, 5 ]
-  }
-}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -32,6 +32,6 @@ jobs:
       - name: Publish release
         run: npx ci-semantic-release
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN_TELERIK }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
           token: ${{ secrets.GH_TOKEN }}
 
       - name: Install modules
-        run: npm install @telerik/semantic-prerelease@1 --no-save
+        run: npm install @progress/semantic-prerelease --no-save
 
       - name: Fast-forward master to develop
         run: npx release-master

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Additionally, the library requires you to load:
 * The `weekData` for the day of week formatting.
 
 ```javascript
-import { load } from '@telerik/kendo-intl';
+import { load } from '@progress/kendo-intl';
 
 load(
     require("cldr-data/supplemental/likelySubtags.json"),
@@ -55,7 +55,7 @@ For more examples and available configuration options, refer to the article on [
 Date parsing converts a string into a `Date` object by using the specific settings of the locale.
 
 ```js
-import { parseDate } from '@telerik/kendo-intl';
+import { parseDate } from '@progress/kendo-intl';
 
 parseDate("11/6/2000", ["G", "d"]); // Mon Nov 06 2000
 parseDate("Montag, 6.11.2000", "EEEE, d.MM.y", "de"); // Mon Nov 06 2000
@@ -69,7 +69,7 @@ For more examples and available configuration options, refer to the article on [
 Date formatting converts a `Date` object into a human-readable string by using the specific settings of the locale.
 
 ```js
-import { formatDate } from '@telerik/kendo-intl';
+import { formatDate } from '@progress/kendo-intl';
 
 formatDate(new Date(2000, 10, 6), "d"); // 11/6/2000
 formatDate(new Date(2000, 10, 6), "yMd", "de"); // 6.11.2000
@@ -83,7 +83,7 @@ For more examples and available configuration options, refer to the article on [
 Number parsing converts a string into a `Number` object by using the specific settings of the locale.
 
 ```js
-import { parseNumber } from '@telerik/kendo-intl';
+import { parseNumber } from '@progress/kendo-intl';
 
 parseNumber("12.22"); // 12.22
 parseNumber("1.212,22 €", "de"); // 1212.22
@@ -98,7 +98,7 @@ For more examples and available configuration options, refer to the article on [
 Number formatting converts a `Number` object into a human-readable string using the specific settings of the locale.
 
 ```js
-import { formatNumber } from '@telerik/kendo-intl';
+import { formatNumber } from '@progress/kendo-intl';
 
 formatNumber(1234.567, "n2"); // 1,234.57
 
@@ -120,7 +120,7 @@ For more examples and available configuration options, refer to the article on [
 General formatting provides methods for independent placeholder and type formatting by using the specific settings of the locale.
 
 ```js
-import { format, toString } from '@telerik/kendo-intl';
+import { format, toString } from '@progress/kendo-intl';
 
 format('Date: {0:d} - Price: {1:c}', [new Date(), 10.5], "en") // Date: 1/5/2017 - Price: $10.50
 
@@ -138,20 +138,20 @@ For more examples and available configuration options, refer to the article on [
 2. Download and install the module:
 
     ```bash
-    npm install --save '@telerik/kendo-intl';
+    npm install --save '@progress/kendo-intl';
     ```
 
 3. Once installed, import the Internationalization in your application root module:
 
     ```javascript
     // ES2015 module syntax
-    import { formatDate, parseDate } from '@telerik/kendo-intl';
+    import { formatDate, parseDate } from '@progress/kendo-intl';
     //or
-    import { formatNumber, parseNumber } from '@telerik/kendo-intl';
+    import { formatNumber, parseNumber } from '@progress/kendo-intl';
     ```
     ```javascript
     // CommonJS format
-    var numbers = require('@telerik/kendo-intl/number').numbers;
+    var numbers = require('@progress/kendo-intl/number').numbers;
     //or
-    var dates = require('@telerik/kendo-intl/dates').dates;
+    var dates = require('@progress/kendo-intl/dates').dates;
     ```

--- a/docs/cldr/index.md
+++ b/docs/cldr/index.md
@@ -39,7 +39,7 @@ To load the CLDR data, use the [`load`](https://github.com/telerik/kendo-intl/bl
 > Before other culture scripts, you have to load the supplemental data first. It requires you to load it just once.
 
 ```
-import { cldr, load } from '@telerik/kendo-intl';
+import { cldr, load } from '@progress/kendo-intl';
 
 const likelySubtags = require("cldr-data/supplemental/likelySubtags.json");
 const weekData      = require("cldr-data/supplemental/weekData.json");
@@ -75,8 +75,8 @@ The `build` method the kendo-intl package provides generates the files which use
 The following example demonstrates how to generate the data for typescript projects.
 
 ```
-const { buildLocales, toJSObject } = require('@telerik/kendo-intl/build-locales');
-const intl = require('@telerik/kendo-intl');
+const { buildLocales, toJSObject } = require('@progress/kendo-intl/build-locales');
+const intl = require('@progress/kendo-intl');
 
 const localeTemplate = (data) => {
     return `export const data = ${ toJSObject(data) };`;
@@ -95,7 +95,7 @@ The method outputs four files in the destination locale folder. These are:
 To set the generated data, use the [`setData`](https://github.com/telerik/kendo-intl/blob/master/docs/cldr/api.md#setdata) method.
 
 ```
-import { setData } from '@telerik/kendo-intl';
+import { setData } from '@progress/kendo-intl';
 import { data } from './locales/bg/all';
 
 setData(data);

--- a/docs/date-formatting/index.md
+++ b/docs/date-formatting/index.md
@@ -23,79 +23,79 @@ The supported types of date formats are:
 
 * **The `d` specifier**&mdash;Renders a short date pattern: `"M/d/y"` for en.
 
-        import { formatDate } from '@telerik/kendo-intl';
+        import { formatDate } from '@progress/kendo-intl';
 
         formatDate(new Date(2000, 10, 6), "d"); // 10/6/2000
 
 * **The `D` specifier**&mdash;Renders a long date pattern: `"EEEE, MMMM d, y"` for en.
 
-        import { formatDate } from '@telerik/kendo-intl';
+        import { formatDate } from '@progress/kendo-intl';
 
         formatDate(new Date(2000, 10, 6), "D"); // Monday, November 6, 2000
 
 * **The `F` specifier**&mdash;Renders a full date and time pattern: `"EEEE, MMMM d, y h:mm:ss a"` for en.
 
-        import { formatDate } from '@telerik/kendo-intl';
+        import { formatDate } from '@progress/kendo-intl';
 
         formatDate(new Date(2000, 10, 6), "F"); // Monday, November 6, 2000 12:00:00 AM
 
 * **The `g` specifier**&mdash;Renders a general date and time pattern (short time): `"M/d/y h:mm a"` for en.
 
-        import { formatDate } from '@telerik/kendo-intl';
+        import { formatDate } from '@progress/kendo-intl';
 
         formatDate(new Date(2000, 10, 6), "g"); // 11/6/2000 12:00 AM
 
 * **The `G` specifier**&mdash;Renders a general date and time pattern (long time): `"M/d/y h:mm:ss a"` for en.
 
-        import { formatDate } from '@telerik/kendo-intl';
+        import { formatDate } from '@progress/kendo-intl';
 
         formatDate(new Date(2000, 10, 6), "G"); // 11/6/2000 12:00:00 AM
 
 * **The `M` specifier**&mdash;Renders a wide month and day pattern: `"MMMM d"` for en.
 
-        import { formatDate } from '@telerik/kendo-intl';
+        import { formatDate } from '@progress/kendo-intl';
 
         formatDate(new Date(2000, 10, 6), "M"); // November 6
 
 * **The `m` specifier**&mdash;Renders an abbreviated month and day pattern: `"MMM d"` for en.
 
-        import { formatDate } from '@telerik/kendo-intl';
+        import { formatDate } from '@progress/kendo-intl';
 
         formatDate(new Date(2000, 10, 6), "m"); // Nov 6
 
 * **The `Y` specifier**&mdash;Renders a wide month and year pattern: `"MMMM y"` for en.
 
-        import { formatDate } from '@telerik/kendo-intl';
+        import { formatDate } from '@progress/kendo-intl';
 
         formatDate(new Date(2000, 10, 6), "Y"); // November 2000
 
 * **The `y` specifier**&mdash;Renders an abbreviated month/year pattern: `"MMM y"` for en.
 
-        import { formatDate } from '@telerik/kendo-intl';
+        import { formatDate } from '@progress/kendo-intl';
 
         formatDate(new Date(2000, 10, 6), "y"); // Nov 2000
 
 * **The `t` specifier**&mdash;Renders a short time pattern: `"h:mm a"` for en.
 
-        import { formatDate } from '@telerik/kendo-intl';
+        import { formatDate } from '@progress/kendo-intl';
 
         formatDate(new Date(2000, 10, 6, 14, 30, 45), "t"); // 2:30 PM
 
 * **The `T` specifier**&mdash;Renders a long time pattern: `"h:mm:ss a"` for en.
 
-        import { formatDate } from '@telerik/kendo-intl';
+        import { formatDate } from '@progress/kendo-intl';
 
         formatDate(new Date(2000, 10, 6, 14, 30, 45), "T"); // 2:30:45 PM
 
 * **The `s` specifier**&mdash;Renders a universal sortable local date and time pattern: `"yyyy-MM-dd HH:mm:ss"`.
 
-        import { formatDate } from '@telerik/kendo-intl';
+        import { formatDate } from '@progress/kendo-intl';
 
         formatDate(new Date(2000, 10, 6), "s"); // 2000-11-06T00:00:00
 
 * **The `u` specifier**&mdash;Renders a universal sortable UTC date and time pattern: `"yyyy-MM-dd HH:mm:ssZ"`.
 
-        import { formatDate } from '@telerik/kendo-intl';
+        import { formatDate } from '@progress/kendo-intl';
 
         formatDate(new Date(2000, 10, 6), "u"); // 2000-11-06 00:00:00Z
 
@@ -107,7 +107,7 @@ The following specifiers can be used in the custom formats.
 
     For the abbreviated name, use one to three letters. For the wide name, use four letters. For the narrow name, use five letters.
 
-        import { formatDate } from '@telerik/kendo-intl';
+        import { formatDate } from '@progress/kendo-intl';
 
         formatDate(new Date(2000, 0, 1), "y G"); // 2000 AD
 
@@ -115,7 +115,7 @@ The following specifiers can be used in the custom formats.
 
     To render the full year, use one letter. To render a two-digit year, use two letters. To render a zero-padded year, if necessary, use three or four letters.
 
-        import { formatDate } from '@telerik/kendo-intl';
+        import { formatDate } from '@progress/kendo-intl';
 
         formatDate(new Date(2000, 0, 1), "y"); // 2000
 
@@ -127,7 +127,7 @@ The following specifiers can be used in the custom formats.
 
     For the numerical quarter, use one or two letters. For the abbreviation, use three letters. For the wide name, use four letters. For the narrow name, use five letters.
 
-        import { formatDate } from '@telerik/kendo-intl';
+        import { formatDate } from '@progress/kendo-intl';
 
         formatDate(new Date(2000, 0, 1), "Q"); // 1
 
@@ -145,7 +145,7 @@ The following specifiers can be used in the custom formats.
 
   When you use two letters, the month number is rendered as zero-padded.
 
-        import { formatDate } from '@telerik/kendo-intl';
+        import { formatDate } from '@progress/kendo-intl';
 
         formatDate(new Date(2000, 0, 1), "M"); // 1
 
@@ -163,7 +163,7 @@ The following specifiers can be used in the custom formats.
 
   To show the minimum number of digits, use `"d"`. To always show two digits, use `"dd"` (zero-padding, if necessary&mdash;for example, "08").
 
-        import { formatDate } from '@telerik/kendo-intl';
+        import { formatDate } from '@progress/kendo-intl';
 
         formatDate(new Date(2000, 0, 1), "y d"); // 2000 1
 
@@ -173,7 +173,7 @@ The following specifiers can be used in the custom formats.
 
   For the abbreviated day name, use one through three letters. For the wide name, use four letters. For the narrow name, use five letters. For the short name, use six letters.
 
-        import { formatDate } from '@telerik/kendo-intl';
+        import { formatDate } from '@progress/kendo-intl';
 
         formatDate(new Date(2000, 0, 1), "E"); // Sat
 
@@ -185,7 +185,7 @@ The following specifiers can be used in the custom formats.
 
 * **The `"e"` specifier**&mdash;The same as the `"E"` specifier except that it adds a numeric value that depends on the local starting day of the week, using one or two letters. The format requires you to load the supplemental `weekData`.
 
-        import { formatDate } from '@telerik/kendo-intl';
+        import { formatDate } from '@progress/kendo-intl';
 
         formatDate(new Date(2000, 0, 1), "e"); // 7
 
@@ -195,7 +195,7 @@ The following specifiers can be used in the custom formats.
 
   For the short name, use one through three letters. For the wide name, use four letters. For the narrow name, use five letters.
 
-        import { formatDate } from '@telerik/kendo-intl';
+        import { formatDate } from '@progress/kendo-intl';
 
         formatDate(new Date(2000, 0, 1), "a"); // AM
 
@@ -207,7 +207,7 @@ The following specifiers can be used in the custom formats.
 
   To show the minimum number of digits, use `"h"`. To always show two digits, use `"hh"`.
 
-        import { formatDate } from '@telerik/kendo-intl';
+        import { formatDate } from '@progress/kendo-intl';
 
         formatDate(new Date(2000, 0, 1, 13), "h a"); // 1 PM
 
@@ -217,7 +217,7 @@ The following specifiers can be used in the custom formats.
 
   To show the minimum number of digits, use `"H"`. To always show two digits, use `"HH"`.
 
-        import { formatDate } from '@telerik/kendo-intl';
+        import { formatDate } from '@progress/kendo-intl';
 
         formatDate(new Date(2000, 0, 1, 1), "H:mm"); // 1:00
 
@@ -227,7 +227,7 @@ The following specifiers can be used in the custom formats.
 
   To show the minimum number of digits, use `"k"`. To always show two digits, use `"kk"`.
 
-        import { formatDate } from '@telerik/kendo-intl';
+        import { formatDate } from '@progress/kendo-intl';
 
         formatDate(new Date(2000, 0, 1, 0), "k"); // 24
 
@@ -239,7 +239,7 @@ The following specifiers can be used in the custom formats.
 
   To show the minimum number of digits, use `"K"`. To always show two digits, use `"KK"`.
 
-        import { formatDate } from '@telerik/kendo-intl';
+        import { formatDate } from '@progress/kendo-intl';
 
         formatDate(new Date(2000, 0, 1, 0), "K a"); // 0 AM
 
@@ -253,7 +253,7 @@ The following specifiers can be used in the custom formats.
 
   To show the minimum number of digits, use `"m"`. To always show two digits, use `"mm"`.
 
-        import { formatDate } from '@telerik/kendo-intl';
+        import { formatDate } from '@progress/kendo-intl';
 
         formatDate(new Date(2000, 0, 1, 1, 1), "H:m"); // 1:1
 
@@ -263,7 +263,7 @@ The following specifiers can be used in the custom formats.
 
   To show the minimum number of digits, use `"s"`. To always show two digits, use `"ss"`.
 
-        import { formatDate } from '@telerik/kendo-intl';
+        import { formatDate } from '@progress/kendo-intl';
 
         formatDate(new Date(2000, 0, 1, 1, 1, 1), "HH:mm:s"); // 01:01:1
 
@@ -271,7 +271,7 @@ The following specifiers can be used in the custom formats.
 
 * **The `"S"` specifier**&mdash;Renders the fractional seconds. It truncates based on the number of letters.
 
-        import { formatDate } from '@telerik/kendo-intl';
+        import { formatDate } from '@progress/kendo-intl';
 
         formatDate(new Date(2000, 0, 1, 1, 1, 1, 123), "s.S"); // 1.1
 
@@ -283,7 +283,7 @@ The following specifiers can be used in the custom formats.
 
   For the short localized GMT format, use one through three letters. For the long localized GMT format, use four letters.
 
-        import { formatDate } from '@telerik/kendo-intl';
+        import { formatDate } from '@progress/kendo-intl';
 
         formatDate(new Date(2000, 0, 1), "z"); // GMT+2
 
@@ -293,7 +293,7 @@ The following specifiers can be used in the custom formats.
 
   To show the ISO8601 basic format with hours and minutes, use one through three letters. For the long localized GMT format, use four letters. For the ISO8601 extended format, use five letters.
 
-        import { formatDate } from '@telerik/kendo-intl';
+        import { formatDate } from '@progress/kendo-intl';
 
         formatDate(new Date(2000, 0, 1), "Z"); // +0200
 
@@ -307,7 +307,7 @@ The following specifiers can be used in the custom formats.
 
   When the local time offset is `0` (zero), use the ISO8601 UTC indicator `Z`.
 
-        import { formatDate } from '@telerik/kendo-intl';
+        import { formatDate } from '@progress/kendo-intl';
 
         formatDate(new Date(2000, 0, 1), "X"); // +02
 
@@ -327,7 +327,7 @@ The supported types of options are:
 
 * **Locale predefined formats**&mdash;Sets the format from the [`dateFormats`](http://www.unicode.org/reports/tr35/tr35-dates.html#dateFormats), [`timeFormats`](http://www.unicode.org/reports/tr35/tr35-dates.html#timeFormats), and [`dateTimeFormats`](http://www.unicode.org/reports/tr35/tr35-dates.html#dateTimeFormats) elements of the calendar.
 
-        import { formatDate } from '@telerik/kendo-intl';
+        import { formatDate } from '@progress/kendo-intl';
 
         formatDate(new Date(2000, 10, 6, 13), { time: "short" }); // 1:00 PM
 
@@ -337,13 +337,13 @@ The supported types of options are:
 
 * **Skeleton formats**&mdash;Sets the format from the [`availableFormats`](http://www.unicode.org/reports/tr35/tr35-dates.html#availableFormats_appendItems) of the calendar based on the date fields that you want to display.
 
-        import { formatDate } from '@telerik/kendo-intl';
+        import { formatDate } from '@progress/kendo-intl';
 
         formatDate(new Date(2000, 10, 6, 13), { skeleton: "yMMMdEHm" }); // Mon, Nov 6, 2000, 13:00
 
 * **Fields formats**&mdash;Similar to the skeleton formats except that you need to set the required fields by using separate options in the same way as the [`Intl.DateTimeFormat`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat) object.
 
-        import { formatDate } from '@telerik/kendo-intl';
+        import { formatDate } from '@progress/kendo-intl';
 
         formatDate(new Date(2000, 10, 6), { year: "numeric", month: "long" }); // November 2000
 
@@ -353,7 +353,7 @@ To utilize or manipulate individual parts of the format, you might need more det
 
 The following example demonstrates how to implement the usage of abbreviated names in a predefined format.
 
-    import { formatDate, splitDateFormat } from '@telerik/kendo-intl';
+    import { formatDate, splitDateFormat } from '@progress/kendo-intl';
 
     const date = new Date(2000, 0, 1);
 

--- a/docs/date-parsing/index.md
+++ b/docs/date-parsing/index.md
@@ -48,7 +48,7 @@ You can pass the formats that have to be used to parse the value as parameters t
 
 The following example demonstrates how to specify the parse formats.
 
-    import { parseDate } from '@telerik/kendo-intl';
+    import { parseDate } from '@progress/kendo-intl';
 
     parseDate("2000/11/06", "yyyy/MM/dd");
 

--- a/docs/general-formatting/index.md
+++ b/docs/general-formatting/index.md
@@ -21,7 +21,7 @@ The supported types of general formatting are:
 
 To replace the format string placeholders (`{index}`) with the provided values based on the index, use the `format` method. You can also set a specific format specified for `Date` and `Number` values by adding `:format` after the index.
 
-    import { format } from '@telerik/kendo-intl';
+    import { format } from '@progress/kendo-intl';
 
     format('Date: {0:d} - Price: {1:c}', [new Date(), 10.5], "en"); // Date: 1/5/2017 - Price: $10.50
 
@@ -29,7 +29,7 @@ To replace the format string placeholders (`{index}`) with the provided values b
 
 To format both the `Date` and `Number` values by using the locale specific settings, apply the `toString` method. If you pass a string as a value, it is returned without any modification.
 
-    import { toString } from '@telerik/kendo-intl';
+    import { toString } from '@progress/kendo-intl';
 
     toString(new Date(), "d", "en"); // 1/5/2017
 

--- a/docs/num-formatting/index.md
+++ b/docs/num-formatting/index.md
@@ -23,7 +23,7 @@ Standard number formatting can be specified by passing an options object or a st
 
 * **The `"n"` specifier**&mdash;Formats the number as a decimal number based on the locale. To specify precision, add a number after `"n"`. By default, the number is formatted and rounded to three decimal digits.
 
-        import { formatNumber } from '@telerik/kendo-intl';
+        import { formatNumber } from '@progress/kendo-intl';
 
         formatNumber(1234.5678, "n"); // 1,234.568
 
@@ -35,7 +35,7 @@ Standard number formatting can be specified by passing an options object or a st
 
   > In order for the currency formatting to work, load the locale numbers `currencies` data and the supplemental `currencyData`.
 
-        import { formatNumber } from '@telerik/kendo-intl';
+        import { formatNumber } from '@progress/kendo-intl';
 
         formatNumber(1234.5678, "c"); // $1,234.57
 
@@ -47,7 +47,7 @@ Standard number formatting can be specified by passing an options object or a st
 
   > In order for the currency formatting to work, load the locale numbers `currencies` data and the supplemental `currencyData`.
 
-        import { formatNumber } from '@telerik/kendo-intl';
+        import { formatNumber } from '@progress/kendo-intl';
 
         formatNumber(-1234.5678, "a"); // ($1,234.57)
 
@@ -55,7 +55,7 @@ Standard number formatting can be specified by passing an options object or a st
 
 * **The `"p"` specifier**&mdash;Formats the number as a percentage based on the locale. The passed number is multiplied by 100. To specify precision, add a number after `"p"`. By default, the number is formatted and rounded to zero decimal digits.
 
-        import { formatNumber } from '@telerik/kendo-intl';
+        import { formatNumber } from '@progress/kendo-intl';
 
         formatNumber(0.5678, "p"); // 57%
 
@@ -65,13 +65,13 @@ Standard number formatting can be specified by passing an options object or a st
 
 * **The `"e"` specifier**&mdash;Formats the number in exponential notation.
 
-        import { formatNumber } from '@telerik/kendo-intl';
+        import { formatNumber } from '@progress/kendo-intl';
 
         formatNumber(0.45678, "e0"); // 5e-1
 
   Apart from setting a string, you can also specify the standard formats by passing an object with the style option.
 
-        import { formatNumber } from '@telerik/kendo-intl';
+        import { formatNumber } from '@progress/kendo-intl';
 
         formatNumber(1234.5678, {
             style: "decimal",
@@ -98,13 +98,13 @@ The supported format specifiers are:
 
 * **The `"0"` specifier**&mdash;A zero placeholder. It replaces the zero with the corresponding digit if one is present. Otherwise, zero appears in the result string.
 
-        import { formatNumber } from '@telerik/kendo-intl';
+        import { formatNumber } from '@progress/kendo-intl';
 
         formatNumber(1234.5678, "00000"); // 01235
 
 * **The `"#"` specifier**&mdash;A digit placeholder. It replaces the Pound sign with the corresponding digit if one is present. Otherwise, no digit appears in the result string.
 
-        import { formatNumber } from '@telerik/kendo-intl';
+        import { formatNumber } from '@progress/kendo-intl';
 
         formatNumber(1234.5678, "#####"); // 1235
 
@@ -112,13 +112,13 @@ The supported format specifiers are:
 
 * **The `"."` specifier**&mdash;A decimal placeholder. It determines the location of the decimal separator in the result string.
 
-        import { formatNumber } from '@telerik/kendo-intl';
+        import { formatNumber } from '@progress/kendo-intl';
 
         formatNumber(0.45678, "0.00"); // 0.46
 
 * **The `","` specifier**&mdash;A group separator placeholder. It inserts a localized group separator between each group.
 
-        import { formatNumber } from '@telerik/kendo-intl';
+        import { formatNumber } from '@progress/kendo-intl';
 
         formatNumber(12345678, "##,#"); // 12,345,678
 
@@ -126,7 +126,7 @@ The supported format specifiers are:
 
   > The `%` symbol is interpreted as a format specifier in the format string. To prevent this, precede the `%` symbol with a double backslash&mdash;`formatNumber(12, "# \\\%")` resulting in `12 %`.
 
-        import { formatNumber } from '@telerik/kendo-intl';
+        import { formatNumber } from '@progress/kendo-intl';
 
         formatNumber(1.1, "#.0 %"); // 110.0 %
 
@@ -134,19 +134,19 @@ The supported format specifiers are:
 
   > The `$` symbol is interpreted as a format specifier in the format string. To prevent this, precede the `$` symbol with a double backslash&mdash;`formatNumber(12, "# \\\$")` resulting in `12 $`.
 
-        import { formatNumber } from '@telerik/kendo-intl';
+        import { formatNumber } from '@progress/kendo-intl';
 
         formatNumber(-123, "##,# $", "de"); // 12.345.678 €
 
 * **The `";"` specifier**&mdash;A section separator. It defines sections with separate format strings for positive, negative, and zero numbers.
 
-        import { formatNumber } from '@telerik/kendo-intl';
+        import { formatNumber } from '@progress/kendo-intl';
 
         formatNumber(-123, "##,#;(##,#)"); // (123)
 
 * **The `"string"/'string'` specifier**&mdash;A literal string delimiter. It indicates that the enclosed characters should be copied to the result string.
 
-        import { formatNumber } from '@telerik/kendo-intl';
+        import { formatNumber } from '@progress/kendo-intl';
 
         formatNumber(12345678, "##,# '$'", "de"); // 12.345.678 $
 

--- a/docs/num-parsing/index.md
+++ b/docs/num-parsing/index.md
@@ -23,7 +23,7 @@ The `parseNumber` method supports the parsing of the following string formats:
 
 It parses strings representing numbers with the specific group and decimal separators of the locale.
 
-    import { parseNumber } from '@telerik/kendo-intl';
+    import { parseNumber } from '@progress/kendo-intl';
 
     parseNumber("123.456,789", "de"); // 123456.789
 
@@ -33,13 +33,13 @@ It parses strings representing numbers with the specific separators and currency
 
 The following example demonstrates the basic currency format.
 
-    import { parseNumber } from '@telerik/kendo-intl';
+    import { parseNumber } from '@progress/kendo-intl';
 
     parseNumber("$123,456.789"); // 123456.789
 
 The following example demonstrates a non-default currency format.
 
-    import { parseNumber } from '@telerik/kendo-intl';
+    import { parseNumber } from '@progress/kendo-intl';
 
     parseNumber("€123,456,789.00", "en", { currency: "EUR" }); // 123456789
 
@@ -47,7 +47,7 @@ The following example demonstrates a non-default currency format.
 
 It parses strings representing percentages with specific separators and percent symbol of the locale. The parsed number is divided by 100.
 
-    import { parseNumber } from '@telerik/kendo-intl';
+    import { parseNumber } from '@progress/kendo-intl';
 
     parseNumber("50%"); // 0.5
 
@@ -55,7 +55,7 @@ It parses strings representing percentages with specific separators and percent 
 
 It parses strings representing exponential numbers with the specific decimal separator of the locale.
 
-    import { parseNumber } from '@telerik/kendo-intl';
+    import { parseNumber } from '@progress/kendo-intl';
 
     parseNumber("1,5e+7", "de"); // 15000000
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@telerik/kendo-intl",
+  "name": "@progress/kendo-intl",
   "description": "A package exporting functions for date and number parsing and formatting",
   "author": "Telerik",
   "license": "Apache-2.0",
@@ -13,20 +13,21 @@
     "build-package": "gulp build-rollup-package build-cdn",
     "test": "gulp test",
     "locale-tests": "gulp test --tests=\"locale-tests/generated-locales.js\"",
-    "lint": "gulp lint",
+    "lint": "eslint ./src",
     "semantic-release": "semantic-release pre && semantic-prerelease publish && semantic-release post"
   },
   "keywords": [
     "Kendo",
     "Internationalization"
   ],
-  "dependencies": {},
   "devDependencies": {
-    "@telerik/eslint-config": "^1.0.0",
-    "@progress/kendo-package-tasks": "^4.0.34",
-    "@telerik/semantic-prerelease": "^1.3.3",
+    "@progress/kendo-package-tasks": "dev",
+    "@progress/semantic-prerelease": "^3.0.0",
+    "@typescript-eslint/eslint-plugin": "^5.27.0",
+    "@typescript-eslint/parser": "^5.27.0",
     "cldr-data": "latest",
     "cz-conventional-changelog": "^1.1.5",
+    "eslint": "^8.16.0",
     "ghooks": "^1.0.3",
     "gulp": "^4.0.0",
     "semantic-release": "^6.3.6",
@@ -53,11 +54,11 @@
     "fallbackTags": {
       "dev": "latest"
     },
-    "analyzeCommits": "@telerik/semantic-prerelease/analyzeCommits",
-    "generateNotes": "@telerik/semantic-prerelease/generateNotes",
-    "getLastRelease": "@telerik/semantic-prerelease/getLastRelease",
-    "verifyConditions": "@telerik/semantic-prerelease/verifyConditions",
-    "verifyRelease": "@telerik/semantic-prerelease/verifyRelease"
+    "analyzeCommits": "@progress/semantic-prerelease/analyzeCommits",
+    "generateNotes": "@progress/semantic-prerelease/generateNotes",
+    "getLastRelease": "@progress/semantic-prerelease/getLastRelease",
+    "verifyConditions": "@progress/semantic-prerelease/verifyConditions",
+    "verifyRelease": "@progress/semantic-prerelease/verifyRelease"
   },
   "cldr-data-coverage": "full",
   "files": [

--- a/src/cldr/currency.js
+++ b/src/cldr/currency.js
@@ -114,7 +114,7 @@ export function currencyDisplay(locale, options) {
     if (currencyDisplay === SYMBOL) {
         result = currencyInfo["symbol-alt-narrow"] || currencyInfo[SYMBOL];
     } else {
-        if (typeof value === undefined || value !== 1) {
+        if (typeof value === "undefined" || value !== 1) {
             result = currencyInfo["displayName-count-other"];
         } else {
             result = currencyInfo["displayName-count-one"];

--- a/src/dates/parse-date.js
+++ b/src/dates/parse-date.js
@@ -7,7 +7,7 @@ import datePattern from './date-pattern';
 import round from '../common/round';
 import isDate from '../common/is-date';
 
-const timeZoneOffsetRegExp = /([+|\-]\d{1,2})(:?)(\d{2})?/;
+const timeZoneOffsetRegExp = /([+|-]\d{1,2})(:?)(\d{2})?/;
 const dateRegExp = /^\/Date\((.*?)\)\/$/;
 const offsetRegExp = /[+-]\d*/;
 const numberRegExp = {

--- a/src/format.js
+++ b/src/format.js
@@ -4,7 +4,7 @@ import { EMPTY } from './common/constants';
 import isDate from './common/is-date';
 import isNumber from './common/is-number';
 
-const formatRegExp = /\{(\d+)(:[^\}]+)?\}/g;
+const formatRegExp = /\{(\d+)(:[^}]+)?\}/g;
 
 export function toString(value, format, locale) {
     if (format) {

--- a/src/numbers/custom-number-format.js
+++ b/src/numbers/custom-number-format.js
@@ -9,7 +9,7 @@ const ZERO = "0";
 
 const trailingZerosRegExp = /(\.(?:[0-9]*[1-9])?)0+$/g;
 const trailingPointRegExp = /\.$/;
-const commaRegExp = /\,/g;
+const commaRegExp = /,/g;
 
 function trimTrailingZeros(value, lastZero) {
     let trimRegex;

--- a/src/numbers/parse-number.js
+++ b/src/numbers/parse-number.js
@@ -6,7 +6,7 @@ import isCurrencyStyle from './is-currency-style';
 import formatOptions from './format-options';
 import isString from '../common/is-string';
 
-const exponentRegExp = /[eE][\-+]?[0-9]+/;
+const exponentRegExp = /[eE][-+]?[0-9]+/;
 const nonBreakingSpaceRegExp = /\u00A0/g;
 
 function cleanNegativePattern(number, patterns) {


### PR DESCRIPTION
Cleaning up the `@telerik` scope for internal usage.

Package will be released as `@progress/kendo-intl` v3.0.0