### PR TITLE
fix: parseNumber fails with specific percent numbers

### DIFF
--- a/src/numbers/parse-number.js
+++ b/src/numbers/parse-number.js
@@ -70,6 +70,20 @@ function cleanLiterals(number, formatOptions) {
     return result;
 }
 
+function divideBy100(number) {
+    const strNumber = String(number);
+    const pointIndex = strNumber.indexOf(POINT);
+    const zeroesCount = 2;
+    let result = number / Math.pow(10, zeroesCount);
+
+    if (pointIndex === -1 || String(result).length <= strNumber.length + zeroesCount) {
+        return result;
+    }
+
+    const fractionDigits = strNumber.length - pointIndex + 1 + zeroesCount;
+    return parseFloat(result.toFixed(fractionDigits));
+}
+
 export default function parseNumber(value, locale = DEFAULT_LOCALE, format = {}) {
     if (!value && value !== 0) {
         return null;
@@ -130,7 +144,7 @@ export default function parseNumber(value, locale = DEFAULT_LOCALE, format = {})
     }
 
     if (number && isPercent) {
-        number /= 100;
+        number = divideBy100(number);
     }
 
     return number;

--- a/test/numbers.test.js
+++ b/test/numbers.test.js
@@ -776,6 +776,30 @@ describe('parseNumber', () => {
         expect(parseNumber("1,23432e+5", "bg")).toEqual(123432);
     });
 
+    it("parses 0.70% to percent", () => {
+        expect(parseNumber('0.70%')).toEqual(0.007);
+    });
+
+    it("parses 0.14% to percent", () => {
+        expect(parseNumber('0.14%')).toEqual(0.0014);
+    });
+
+    it("parses 0.141% to percent", () => {
+        expect(parseNumber('0.141%')).toEqual(0.00141);
+    });
+
+    it("parses 0.68% to percent", () => {
+        expect(parseNumber('0.68%')).toEqual(0.0068);
+    });
+
+    it("parses 17.17% to percent", () => {
+        expect(parseNumber('17.17%')).toEqual(0.1717);
+    });
+
+    it("parses 0.1234567891245% to percent", () => {
+        expect(parseNumber('0.1234567891245%')).toEqual(0.001234567891245);
+    });
+
     describe('errors', () => {
         beforeAll(() => {
             cldr.supplemental.currencyData.region.CUSTOM = [{ XXX: {} }];


### PR DESCRIPTION
Cannot parse '0.70%' correctly. The error comes from dividing the number by 100.

issue - https://github.com/telerik/kendo-react/issues/1382