### PR TITLE
Symbol fallback

### DIFF
--- a/src/cldr/currency.js
+++ b/src/cldr/currency.js
@@ -112,7 +112,7 @@ export function currencyDisplay(locale, options) {
     let result;
 
     if (currencyDisplay === SYMBOL) {
-        result = currencyInfo["symbol-alt-narrow"] || currencyInfo[SYMBOL];
+        result = currencyInfo["symbol-alt-narrow"] || currencyInfo[SYMBOL] || currency;
     } else {
         if (typeof value === "undefined" || value !== 1) {
             result = currencyInfo["displayName-count-other"];

--- a/test/numbers.test.js
+++ b/test/numbers.test.js
@@ -6,7 +6,10 @@ const numbers = require("cldr-numbers-full/main/bg/numbers.json");
 const currencies = require("cldr-numbers-full/main/bg/currencies.json");
 const currencyData = require("cldr-core/supplemental/currencyData.json");
 
-load(likelySubtags, currencyData, numbers, currencies);
+const localNumbers = require("cldr-numbers-full/main/de-CH/numbers.json");
+const localCurrencies = require("cldr-numbers-full/main/de-CH/currencies.json");
+
+load(likelySubtags, currencyData, numbers, currencies, localNumbers, localCurrencies);
 
 function loadCustom(options) {
     load({
@@ -298,6 +301,10 @@ describe('standard currency formatting', () => {
 
     it("should apply format when passing language and territory", () => {
         expect(formatNumber(10, "c", "bg-BG")).toEqual("10,00 лв.");
+    });
+
+    it("should apply format when passing language and territory without symbol", () => {
+        expect(formatNumber(10, "c", "de-CH")).toEqual("CHF 10.00");
     });
 
     it("should apply format when passing object", () => {


### PR DESCRIPTION
A couple of things here to consider:
- With version `v44` of `cldr-*` packages, it [seems](https://github.com/unicode-org/cldr-json/compare/43.1.0...44.0.0) the `symbol` field has been removed from the `currensies.json` files, unless it's a different symbol. This breaks scenarios where the symbol and the currency abbreviation are the same (e.g. `CHF` currency in `de-CH` lang/locale pair) &mdash; thus the added fallback from the first commit:
![image](https://github.com/telerik/kendo-intl/assets/30626787/c43b9dbd-f4bf-40cb-b108-6a8760e6a71d)
- The removal of the `symbol` field might not be intentional, but rather a regression, since I was not able to find any info on their [changelog](https://cldr.unicode.org/index/downloads/cldr-44)
- Adding a test case as the current one with the `BGN` currency actually have a dedicated symbol.
- The latests cldr version is `44.1`, HOWEVER, they have a failed `44.1.0` deployment of `cldr-core`, which other packages have already listed as dependency. &mdash; thus the version bump
![image](https://github.com/telerik/kendo-intl/assets/30626787/fd05c745-7347-429d-bbf8-7536f523f413)


cc, @telerik/kendo-intl-reviewers 
