### PR TITLE
Аdd publish source workflow

### DIFF
--- a/.github/workflows/publish-source.yml
+++ b/.github/workflows/publish-source.yml
@@ -1,0 +1,18 @@
+# Publishes the source code to the Kendo Git Mirror
+name: Publish Source Code
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: Publish Source Code
+    uses: telerik/kendo-git-mirror/.github/workflows/publish-repo.yml@master
+    secrets: inherit
+    with:
+      branch: master
+      environment: prod
+      dry-run: false


### PR DESCRIPTION
This is a new workflow for publishing the source code to the [Kendo Git Mirror](https://github.com/telerik/kendo-git-mirror/blob/develop/README.md#adding-a-repository-to-the-kendo-git-mirror). It needs to land in `master` by the end of this month when we'll be shutting down the legacy service.

Part of https://github.com/telerik/k2-ci/issues/155